### PR TITLE
remove app.scss

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1,1 +1,0 @@
-// Must be present due to bug in ember-cli / ember-cli-sass 4.0.1


### PR DESCRIPTION
fixes #20.

I'm not quite sure what the error was which is mentioned [here](https://github.com/chrislopresto/ember-freestyle/blob/master/app/styles/app.scss#L1).

There are no build errors in an consuming addon or -app and the styleguide works as expected.