### PR TITLE
Support SCSS Note Snippets

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -7,3 +7,4 @@ files:
     ignore:
       - '**/x-foo.scss'
       - '**/reset.scss'
+      - '**/freestyle-palette-item.scss'

--- a/addon/components/freestyle-section.js
+++ b/addon/components/freestyle-section.js
@@ -6,6 +6,7 @@ const { computed, inject } = Ember;
 export default Ember.Component.extend({
   layout,
   classNames: ['FreestyleSection'],
+  classNameBindings: ['show:FreestyleSection--showing:FreestyleSection--hidden'],
 
   emberFreestyle: inject.service(),
   show: computed('emberFreestyle.section', 'name', function() {

--- a/addon/components/freestyle-usage.js
+++ b/addon/components/freestyle-usage.js
@@ -37,6 +37,9 @@ let FreestyleUsage = Ember.Component.extend({
   snippetNotesHbs: computed('slug', function() {
     return `${this.get('slug')}:notes.hbs`;
   }),
+  snippetNotesScss: computed('slug', function() {
+    return `${this.get('slug')}:notes.scss`;
+  }),
   defaultTheme: computed.alias('emberFreestyle.defaultTheme'),
   // highlightJsTheme - passed in
   computedTheme: computed('defaultTheme', 'highlightJsTheme', function() {

--- a/addon/templates/components/freestyle-usage.hbs
+++ b/addon/templates/components/freestyle-usage.hbs
@@ -18,6 +18,9 @@
     <div class="FreestyleUsage-notes">
       {{freestyle-notes name=snippetNotesHbs theme=computedTheme}}
     </div>
+    <div class="FreestyleUsage-notes">
+      {{freestyle-notes name=snippetNotesScss theme=computedTheme}}
+    </div>
   {{/if}}
   {{#if hasCode}}
     <div class="FreestyleUsage-usage">

--- a/app/styles/components/freestyle-palette-item.scss
+++ b/app/styles/components/freestyle-palette-item.scss
@@ -1,3 +1,13 @@
+/* BEGIN-FREESTYLE-USAGE fpi:notes
+# Markdown Notes In SCSS!
+
+Hey look... these are `mardown` notes:
+
+- coming from scss
+- looking nice
+
+END-FREESTYLE-USAGE */
+
 // BEGIN-FREESTYLE-USAGE fpi
 $freestylePaletteItemBorderColor: #cecece;
 $FreestylePaletteItem-backgroundColor: #fff;

--- a/app/styles/components/freestyle-section.scss
+++ b/app/styles/components/freestyle-section.scss
@@ -11,4 +11,8 @@ $FreestyleSection-borderColor: #ccc;
     padding: 1rem 0 .4rem;
     text-transform: uppercase;
   }
+
+  &--hidden {
+    display: none;
+  }
 }


### PR DESCRIPTION
Support the following snippet in SCSS:

```scss
/* BEGIN-FREESTYLE-USAGE modules-buttons-normal:notes

Use these whenever you need some kind of clickable surface to afford an action that
isn't a boring, inconspicuous text link.

END-FREESTYLE-USAGE */
```