### PR TITLE
WIP - Add ability to set the default theme. Also include most of the available themes in highlight.js

### DIFF
--- a/addon/components/freestyle-guide.js
+++ b/addon/components/freestyle-guide.js
@@ -8,6 +8,7 @@ export default Ember.Component.extend({
   classNames: ['FreestyleGuide'],
 
   emberFreestyle: inject.service(),
+  highlightJsTheme: computed.alias('emberFreestyle.defaultTheme'),
 
   showMenu: computed.alias('emberFreestyle.showMenu'),
   showAside: false,

--- a/addon/components/freestyle-snippet.js
+++ b/addon/components/freestyle-snippet.js
@@ -47,8 +47,9 @@ export default Ember.Component.extend({
   }),
 
   didInsertElement() {
-    if (this.get('source')) {
-      hljs.highlightBlock(this.$('pre')[0]);
+    let pre = this.$('pre');
+    if (pre[0] && this.get('source')) {
+      hljs.highlightBlock(pre[0]);
     }
   },
 

--- a/app/styles/components/freestyle-usage.scss
+++ b/app/styles/components/freestyle-usage.scss
@@ -32,32 +32,292 @@ $FreestyleUsage-maxWidth: $FreestyleGuide-maxWidth !default;
       }
     }
 
-    &--tomorrow-night {
-      @import '../ember-freestyle/highlight.js/tomorrow-night';
-    }
-
     &--zenburn {
       @import '../ember-freestyle/highlight.js/zenburn';
     }
 
-    &--hybrid {
-      @import '../ember-freestyle/highlight.js/hybrid';
+    &--xt256 {
+      @import '../ember-freestyle/highlight.js/xt256';
     }
 
-    &--atelier-cave-dark {
-      @import '../ember-freestyle/highlight.js/atelier-cave-dark';
+    &--xcode {
+      @import '../ember-freestyle/highlight.js/xcode';
+    }
+
+    &--vs {
+      @import '../ember-freestyle/highlight.js/vs';
+    }
+
+    &--tomorrow {
+      @import '../ember-freestyle/highlight.js/tomorrow';
+    }
+
+    &--tomorrow-night {
+      @import '../ember-freestyle/highlight.js/tomorrow-night';
+    }
+
+    &--tomorrow-night-eighties {
+      @import '../ember-freestyle/highlight.js/tomorrow-night-eighties';
+    }
+
+    &--tomorrow-night-bright {
+      @import '../ember-freestyle/highlight.js/tomorrow-night-bright';
+    }
+
+    &--tomorrow-night-blue {
+      @import '../ember-freestyle/highlight.js/tomorrow-night-blue';
+    }
+
+    &--sunburst {
+      @import '../ember-freestyle/highlight.js/sunburst';
     }
 
     &--solarized-light {
       @import '../ember-freestyle/highlight.js/solarized-light';
     }
 
-    &--docco {
-      @import '../ember-freestyle/highlight.js/docco';
+    &--solarized-dark {
+      @import '../ember-freestyle/highlight.js/solarized-dark';
+    }
+
+    &--school-book {
+      @import '../ember-freestyle/highlight.js/school-book';
+    }
+
+    &--rainbow {
+      @import '../ember-freestyle/highlight.js/rainbow';
+    }
+
+    &--railscasts {
+      @import '../ember-freestyle/highlight.js/railscasts';
+    }
+
+    &--qtcreator-light {
+      @import '../ember-freestyle/highlight.js/qtcreator_light';
+    }
+
+    &--qtcreator-dark {
+      @import '../ember-freestyle/highlight.js/qtcreator_dark';
+    }
+
+    &--pojoaque {
+      @import '../ember-freestyle/highlight.js/pojoaque';
+    }
+
+    &--paraiso-light {
+      @import '../ember-freestyle/highlight.js/paraiso-light';
+    }
+
+    &--paraiso-dark {
+      @import '../ember-freestyle/highlight.js/paraiso-dark';
+    }
+
+    &--obsidian {
+      @import '../ember-freestyle/highlight.js/obsidian';
+    }
+
+    &--monokai {
+      @import '../ember-freestyle/highlight.js/monokai';
     }
 
     &--monokai-sublime {
       @import '../ember-freestyle/highlight.js/monokai-sublime';
+    }
+
+    &--mono-blue {
+      @import '../ember-freestyle/highlight.js/mono-blue';
+    }
+
+    &--magula {
+      @import '../ember-freestyle/highlight.js/magula';
+    }
+
+    &--kimbie-light {
+      @import '../ember-freestyle/highlight.js/kimbie.light';
+    }
+
+    &--kimbie-dark {
+      @import '../ember-freestyle/highlight.js/kimbie.dark';
+    }
+
+    &--ir-black {
+      @import '../ember-freestyle/highlight.js/ir-black';
+    }
+
+    &--idea {
+      @import '../ember-freestyle/highlight.js/idea';
+    }
+
+    &--hybrid {
+      @import '../ember-freestyle/highlight.js/hybrid';
+    }
+
+    &--hopscotch {
+      @import '../ember-freestyle/highlight.js/hopscotch';
+    }
+
+    &--gruvbox-light {
+      @import '../ember-freestyle/highlight.js/gruvbox-light';
+    }
+
+    &--gruvbox-dark {
+      @import '../ember-freestyle/highlight.js/gruvbox-dark';
+    }
+
+    &--grayscale {
+      @import '../ember-freestyle/highlight.js/grayscale';
+    }
+
+    &--googlecode {
+      @import '../ember-freestyle/highlight.js/googlecode';
+    }
+
+    &--github {
+      @import '../ember-freestyle/highlight.js/github';
+    }
+
+    &--github-gist {
+      @import '../ember-freestyle/highlight.js/github-gist';
+    }
+
+    &--foundation {
+      @import '../ember-freestyle/highlight.js/foundation';
+    }
+
+    &--far {
+      @import '../ember-freestyle/highlight.js/far';
+    }
+
+    &--dracula {
+      @import '../ember-freestyle/highlight.js/dracula';
+    }
+
+    &--docco {
+      @import '../ember-freestyle/highlight.js/docco';
+    }
+
+    &--default {
+      @import '../ember-freestyle/highlight.js/default';
+    }
+
+    &--darkula {
+      @import '../ember-freestyle/highlight.js/darkula';
+    }
+
+    &--dark {
+      @import '../ember-freestyle/highlight.js/dark';
+    }
+
+    &--color-brewer {
+      @import '../ember-freestyle/highlight.js/color-brewer';
+    }
+
+    &--codepen-embed {
+      @import '../ember-freestyle/highlight.js/codepen-embed';
+    }
+
+    &--brown-paper {
+      @import '../ember-freestyle/highlight.js/brown-paper';
+    }
+
+    &--atelier-sulphurpool-light {
+      @import '../ember-freestyle/highlight.js/atelier-sulphurpool-light';
+    }
+
+    &--atelier-sulphurpool-dark {
+      @import '../ember-freestyle/highlight.js/atelier-sulphurpool-dark';
+    }
+
+    &--atelier-seaside-light {
+      @import '../ember-freestyle/highlight.js/atelier-seaside-light';
+    }
+
+    &--atelier-seaside-dark {
+      @import '../ember-freestyle/highlight.js/atelier-seaside-dark';
+    }
+
+    &--atelier-savanna-light {
+      @import '../ember-freestyle/highlight.js/atelier-savanna-light';
+    }
+
+    &--atelier-savanna-dark {
+      @import '../ember-freestyle/highlight.js/atelier-savanna-dark';
+    }
+
+    &--atelier-plateau-light {
+      @import '../ember-freestyle/highlight.js/atelier-plateau-light';
+    }
+
+    &--atelier-plateau-dark {
+      @import '../ember-freestyle/highlight.js/atelier-plateau-dark';
+    }
+
+    &--atelier-lakeside-light {
+      @import '../ember-freestyle/highlight.js/atelier-lakeside-light';
+    }
+
+    &--atelier-lakeside-dark {
+      @import '../ember-freestyle/highlight.js/atelier-lakeside-dark';
+    }
+
+    &--atelier-heath-light {
+      @import '../ember-freestyle/highlight.js/atelier-heath-light';
+    }
+
+    &--atelier-heath-dark {
+      @import '../ember-freestyle/highlight.js/atelier-heath-dark';
+    }
+
+    &--atelier-forest-light {
+      @import '../ember-freestyle/highlight.js/atelier-forest-light';
+    }
+
+    &--atelier-forest-dark {
+      @import '../ember-freestyle/highlight.js/atelier-forest-dark';
+    }
+
+    &--atelier-estuary-light {
+      @import '../ember-freestyle/highlight.js/atelier-estuary-light';
+    }
+
+    &--atelier-estuary-dark {
+      @import '../ember-freestyle/highlight.js/atelier-estuary-dark';
+    }
+
+    &--atelier-dune-light {
+      @import '../ember-freestyle/highlight.js/atelier-dune-light';
+    }
+
+    &--atelier-dune-dark {
+      @import '../ember-freestyle/highlight.js/atelier-dune-dark';
+    }
+
+    &--atelier-cave-light {
+      @import '../ember-freestyle/highlight.js/atelier-cave-light';
+    }
+
+    &--atelier-cave-dark {
+      @import '../ember-freestyle/highlight.js/atelier-cave-dark';
+    }
+
+    &--ascetic {
+      @import '../ember-freestyle/highlight.js/ascetic';
+    }
+
+    &--arta {
+      @import '../ember-freestyle/highlight.js/arta';
+    }
+
+    &--arduino-light {
+      @import '../ember-freestyle/highlight.js/arduino-light';
+    }
+
+    &--androidstudio {
+      @import '../ember-freestyle/highlight.js/androidstudio';
+    }
+
+    &--agate {
+      @import '../ember-freestyle/highlight.js/agate';
     }
   }
 

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -5,6 +5,10 @@ var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 module.exports = function(defaults) {
   var app = new EmberAddon(defaults, {
     // Add options here
+    babel: {
+      optional: ['es6.spec.symbols'],
+      includePolyfill: true
+    },
     autoprefixer: {
       browsers: ['last 2 version', '> 10%'],
       cascade: false

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,6 +1,7 @@
 {{#freestyle-guide
     title='Ember Freestyle'
     subtitle='Living Style Guide'
+    highlightJsTheme='solarized-light'
 }}
 
   {{#freestyle-section name='Foo Things' as |section|}}
@@ -9,13 +10,20 @@
       {{#freestyle-collection title='Foo Collection' defaultKey='normal' inline=true as |collection|}}
 
         {{#freestyle-variant collection=collection key='normal'}}
+        {{#freestyle-annotation 'foo-normal'}}
+        <h4>A Note About Normal</h4>
+        <p>
+          This comment is coming from a freestyle-annotation component. Use the freestyle-annotation
+          component to write notes in html.
+        </p>
+        {{/freestyle-annotation}}
           {{#freestyle-note 'foo-normal:notes'}}
   #### Another Note About Normal
 
   This comment is coming from a `freestyle-note` component. Use the `freestyle-note` component
   to write notes in markdown.
 
-  ###### Markdown Code Snippet
+  ##### Markdown Code Snippet
 
   ```javascript
   // We can include code blocks using markdown
@@ -24,20 +32,13 @@
   }
   ```
           {{/freestyle-note}}
-          {{#freestyle-annotation 'foo-normal'}}
-            <h4>A Note About Normal</h4>
-            <p>
-              This comment is coming from a freestyle-annotation component. Use the freestyle-annotation
-              component to write notes in html.
-            </p>
-          {{/freestyle-annotation}}
           {{#freestyle-usage 'foo-normal' title='Normal' usageTitle='Usage' hbsTitle='Template'}}
             {{x-foo status='normal'}}
           {{/freestyle-usage}}
         {{/freestyle-variant}}
 
         {{#freestyle-variant collection=collection key='special'}}
-          {{#freestyle-usage 'foo-special' title='Special'}}
+          {{#freestyle-usage 'foo-special' title='Special' highlightJsTheme='zenburn'}}
             {{x-foo status='special'}}
           {{/freestyle-usage}}
         {{/freestyle-variant}}

--- a/tests/integration/components/freestyle-guide/component-test.js
+++ b/tests/integration/components/freestyle-guide/component-test.js
@@ -1,0 +1,40 @@
+/* global expect */
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import usage from '../../../pages/usage-component';
+import Ember from 'ember';
+
+// Stub freestyle service
+const FreestyleStub = Ember.Service.extend({
+  defaultTheme: 'solarized-light'
+});
+
+moduleForComponent('freestyle-guide', 'Integration | Component | freestyle guide', {
+  integration: true,
+
+  beforeEach() {
+    this.register('service:emberFreestyle', FreestyleStub);
+    this.inject.service('emberFreestyle');
+    usage.setContext(this);
+  },
+
+  afterEach() {
+    usage.removeContext();
+  }
+});
+
+test('it sets the passed in highlightJsTheme as the default theme on the service', function(assert) {
+  expect(2);
+
+  assert.equal(this.get('emberFreestyle.defaultTheme'), 'solarized-light');
+  this.render(hbs`
+    {{#freestyle-guide
+        title='Ember Freestyle'
+        subtitle='Living Style Guide'
+        highlightJsTheme='zenburn'
+    }}
+      I am the guide
+    {{/freestyle-guide}}
+    `);
+  assert.equal(this.get('emberFreestyle.defaultTheme'), 'zenburn');
+});

--- a/tests/integration/components/freestyle-usage/component-test.js
+++ b/tests/integration/components/freestyle-usage/component-test.js
@@ -216,3 +216,49 @@ test('it does not render anything if slug does not match the focus', function(as
   assert.equal(usage.numCodeSection, 0);
   assert.equal(usage.numNotesSection, 0);
 });
+
+test('it falls back to the defaultTheme for notes and code snippets if a highlightJsTheme argument is not provided', function(assert) {
+  expect(7);
+
+  this.set('emberFreestyle.snippets', allSnippets);
+  this.set('emberFreestyle.showCode', true);
+  this.set('emberFreestyle.showNotes', true);
+
+  this.set('emberFreestyle.defaultTheme', 'zenburn');
+
+  this.render(hbs`
+    {{#freestyle-usage 'componentA'}}
+      hello from component A
+    {{/freestyle-usage}}
+    `);
+
+  let noteSnippets = usage.notesSection.snippets().toArray();
+  let codeSnippets = usage.usageSection.snippets().toArray();
+  noteSnippets.concat(codeSnippets).forEach((snippet) => {
+    assert.ok(snippet.isZenburn);
+  });
+
+});
+
+test('it uses the passed in highlightJsTheme', function(assert) {
+  expect(7);
+
+  this.set('emberFreestyle.snippets', allSnippets);
+  this.set('emberFreestyle.showCode', true);
+  this.set('emberFreestyle.showNotes', true);
+
+  this.set('emberFreestyle.defaultTheme', 'zenburn');
+
+  this.render(hbs`
+    {{#freestyle-usage 'componentA' highlightJsTheme='solarized-light'}}
+      hello from component A
+    {{/freestyle-usage}}
+    `);
+
+  let noteSnippets = usage.notesSection.snippets().toArray();
+  let codeSnippets = usage.usageSection.snippets().toArray();
+  noteSnippets.concat(codeSnippets).forEach((snippet) => {
+    assert.ok(snippet.isSolarizedLight);
+  });
+
+});

--- a/tests/pages/usage-component.js
+++ b/tests/pages/usage-component.js
@@ -1,7 +1,8 @@
 import PageObject, {
   text,
   count,
-  collection
+  collection,
+  hasClass
 } from 'ember-cli-page-object';
 
 export default PageObject.create({
@@ -15,14 +16,24 @@ export default PageObject.create({
   notesSection: {
     scope: '.FreestyleUsage-notes',
     snippets: collection({
-      itemScope: '.FreestyleUsage-snippet'
+      itemScope: '.FreestyleUsage-snippet',
+
+      item: {
+        isZenburn: hasClass('FreestyleUsage-snippet--zenburn'),
+        isSolarizedLight: hasClass('FreestyleUsage-snippet--solarized-light')
+      }
     })
   },
 
   usageSection: {
     scope: '.FreestyleUsage-usage',
     snippets: collection({
-      itemScope: '.FreestyleUsage-snippet'
+      itemScope: '.FreestyleUsage-snippet',
+
+      item: {
+        isZenburn: hasClass('FreestyleUsage-snippet--zenburn'),
+        isSolarizedLight: hasClass('FreestyleUsage-snippet--solarized-light')
+      }
     })
   }
 


### PR DESCRIPTION
@chrislopresto: Another discussion.

The user can now set the default theme through at `freestyle-guide` level while retaining the felxibility to override it on the `freestyle-usage` component.
