### PR TITLE
Move rendered component next to its corresponding code snippet

### DIFF
--- a/addon/templates/components/freestyle-usage.hbs
+++ b/addon/templates/components/freestyle-usage.hbs
@@ -7,9 +7,6 @@
       </span>
     </div>
   {{/if}}
-  <div class="FreestyleUsage-rendered">
-    {{yield}}
-  </div>
   {{#if hasNotes}}
     <div class="FreestyleUsage-notes">
       <div class="FreestyleUsage-snippet FreestyleUsage-snippet--{{computedTheme}}">
@@ -23,6 +20,9 @@
       </div>
     </div>
   {{/if}}
+  <div class="FreestyleUsage-rendered">
+    {{yield}}
+  </div>
   {{#if hasCode}}
     <div class="FreestyleUsage-usage">
       <div class="FreestyleUsage-snippet FreestyleUsage-snippet--{{computedTheme}}">

--- a/app/styles/components/freestyle-palette-item.scss
+++ b/app/styles/components/freestyle-palette-item.scss
@@ -1,7 +1,7 @@
 /* BEGIN-FREESTYLE-USAGE fpi:notes
 # Markdown Notes In SCSS!
 
-Hey look... these are `mardown` notes:
+Hey look... these are `markdown` notes:
 
 - coming from scss
 - looking nice


### PR DESCRIPTION
Fixes #69.

Before:
![freestyle-order-before](https://cloud.githubusercontent.com/assets/175123/15914627/5259ce2e-2d97-11e6-9bd8-2f8d4def7c85.png)
After:
![freestyle-order-after](https://cloud.githubusercontent.com/assets/175123/15914631/5a12099c-2d97-11e6-98a9-dde2f09bfe8b.png)
