### PR TITLE
Return false for `isDevelopingAddon`

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,6 +83,6 @@ module.exports = {
   },
 
   isDevelopingAddon: function() {
-    return true;
+    return false;
   }
 };


### PR DESCRIPTION
This should always be false for releases. Otherwise the files in the addon are linted alongside the
consuming applications codebase. And possibly other side-effects as well...