### PR TITLE
a11y & template linting fixes

### DIFF
--- a/addon/templates/components/freestyle-usage-controls.hbs
+++ b/addon/templates/components/freestyle-usage-controls.hbs
@@ -6,26 +6,34 @@
   {{/if}}
   <div class="FreestyleUsageControls-item">
     <div class="FreestyleUsageControls-itemControl">
-      {{input type="checkbox" checked=showLabels}}
+      <label class="FreestyleUsageControls-itemLabel">
+        {{input type="checkbox" checked=showLabels}}
+        Show Labels
+      </label>
     </div>
-    <div class="FreestyleUsageControls-itemLabel">Show Labels</div>
   </div>
   <div class="FreestyleUsageControls-item">
     <div class="FreestyleUsageControls-itemControl">
-      {{input type="checkbox" checked=showNotes}}
+      <label class="FreestyleUsageControls-itemLabel">
+        {{input type="checkbox" checked=showNotes}}
+        Show Notes
+      </label>
     </div>
-    <div class="FreestyleUsageControls-itemLabel">Show Notes</div>
   </div>
   <div class="FreestyleUsageControls-item">
     <div class="FreestyleUsageControls-itemControl">
-      {{input type="checkbox" checked=showCode}}
+      <label class="FreestyleUsageControls-itemLabel">
+        {{input type="checkbox" checked=showCode}}
+        Show Code
+      </label>
     </div>
-    <div class="FreestyleUsageControls-itemLabel">Show Code</div>
   </div>
   {{#if showFocus}}
     <div class="FreestyleUsageControls-item FreestyleUsageControls-item--focus">
       <div class="FreestyleUsageControls-itemControl">
-        {{input class="FreestyleUsageControls-input--focus" value=focus}}
+        <label for="focus" class="FreestyleUsageControls-label--focus">Focus a section
+          {{input class="FreestyleUsageControls-input--focus" value=focus name="focus" enter='setFocus'}}
+        </label>
         <button class="FreestyleUsageControls-button" onclick={{action 'setFocus'}}>Focus</button>
       </div>
     </div>

--- a/app/styles/components/freestyle-guide.scss
+++ b/app/styles/components/freestyle-guide.scss
@@ -5,7 +5,7 @@
 // 3. Use `%` instead of `vh` since `vh` is buggy in older mobile Safari.
 
 $FreestyleGuide-maxWidth: 1200px !default;
-$FreestyleGuide-asideBackgroundColor: #fff;
+$FreestyleGuide-asideBackgroundColor: #fff !default;
 $FreestyleGuide-shadow1: rgba(0, 0, 0, .16);
 $FreestyleGuide-shadow2: rgba(0, 0, 0, .12);
 $FreestyleGuide-boxShadow: 0 2px 5px 0 $FreestyleGuide-shadow1, 0 2px 10px 0 $FreestyleGuide-shadow2;

--- a/app/styles/components/freestyle-palette-item.scss
+++ b/app/styles/components/freestyle-palette-item.scss
@@ -9,9 +9,9 @@ Hey look... these are `markdown` notes:
 END-FREESTYLE-USAGE */
 
 // BEGIN-FREESTYLE-USAGE fpi
-$freestylePaletteItemBorderColor: #cecece;
-$FreestylePaletteItem-backgroundColor: #fff;
-$FreestylePaletteItem-color: #808080;
+$freestylePaletteItemBorderColor: #cecece !default;
+$FreestylePaletteItem-backgroundColor: #fff !default;
+$FreestylePaletteItem-color: #2F4F4F !default;
 
 .FreestylePaletteItem {
   border: solid 1px $freestylePaletteItemBorderColor;

--- a/app/styles/components/freestyle-palette-item.scss
+++ b/app/styles/components/freestyle-palette-item.scss
@@ -11,7 +11,7 @@ END-FREESTYLE-USAGE */
 // BEGIN-FREESTYLE-USAGE fpi
 $freestylePaletteItemBorderColor: #cecece !default;
 $FreestylePaletteItem-backgroundColor: #fff !default;
-$FreestylePaletteItem-color: #2F4F4F !default;
+$FreestylePaletteItem-color: #2f4f4f !default;
 
 .FreestylePaletteItem {
   border: solid 1px $freestylePaletteItemBorderColor;

--- a/app/styles/components/freestyle-section.scss
+++ b/app/styles/components/freestyle-section.scss
@@ -1,4 +1,4 @@
-$FreestyleSection-borderColor: #ccc;
+$FreestyleSection-borderColor: #ccc !default;
 
 .FreestyleSection {
   &-name {

--- a/app/styles/components/freestyle-usage-controls.scss
+++ b/app/styles/components/freestyle-usage-controls.scss
@@ -1,4 +1,4 @@
-$FreestyleUsageControls-backgroundColor: #fff;
+$FreestyleUsageControls-backgroundColor: #fff !default;
 $FreestyleUsageControls-shadow1: rgba(0, 0, 0, .16);
 $FreestyleUsageControls-shadow2: rgba(0, 0, 0, .12);
 $FreestyleUsageControls-boxShadow: 0 2px 5px 0 $FreestyleUsageControls-shadow1, 0 2px 10px 0 $FreestyleUsageControls-shadow2;
@@ -32,7 +32,7 @@ $FreestyleUsageControls-boxShadow: 0 2px 5px 0 $FreestyleUsageControls-shadow1, 
   }
 
   &-itemLabel {
-    font-size: .7rem;
+    font-size: .8rem;
   }
 
   &-input {

--- a/app/styles/components/freestyle-usage.scss
+++ b/app/styles/components/freestyle-usage.scss
@@ -1,4 +1,4 @@
-$FreestyleUsage-borderColor: #cecece;
+$FreestyleUsage-borderColor: #cecece !default;
 $FreestyleUsage-maxWidth: $FreestyleGuide-maxWidth !default;
 
 .FreestyleUsage {

--- a/app/styles/ember-freestyle.scss
+++ b/app/styles/ember-freestyle.scss
@@ -10,7 +10,7 @@ $FreestyleBreakpoints: (
 };
 
 // Default Ember Freestyle Palette
-$FreestyleGuide-color--primary: #00bcd4 !default;
+$FreestyleGuide-color--primary: #0d47a1 !default;
 $FreestyleGuide-color--accent: #ffc107 !default;
 $FreestyleGuide-color--secondary: #b6b6b6 !default;
 $FreestyleGuide-color--foreground: #212121 !default;

--- a/blueprints/ember-freestyle/files/__root__/app/templates/freestyle.hbs
+++ b/blueprints/ember-freestyle/files/__root__/app/templates/freestyle.hbs
@@ -1,7 +1,7 @@
 {{#freestyle-guide
-    title='Ember Freestyle'
-    subtitle='Living Style Guide'
-}}
+  title='Ember Freestyle'
+  subtitle='Living Style Guide'
+  }}
 
   {{#freestyle-section name='Visual Style' as |section|}}
 
@@ -21,9 +21,9 @@
 
       {{#freestyle-usage 'fp' title='Freestyle Palette' usageTitle='Usage'}}
         {{freestyle-palette
-            colorPalette=colorPalette
-            title='Dummy App Color Palette'
-            description='This component displays the color palette specified in freestyle/palette.json'
+        colorPalette=colorPalette
+        title='Dummy App Color Palette'
+        description='This component displays the color palette specified in freestyle/palette.json'
         }}
       {{/freestyle-usage}}
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "ember-cli-qunit": "^1.4.0",
     "ember-cli-release": "0.2.8",
     "ember-cli-sass": "5.3.1",
-    "ember-cli-sass-lint": "sir-dunxalot/ember-cli-sass-lint#feature/in-addon-linting",
+    "ember-cli-sass-lint": "1.0.2",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-disable-prototype-extensions": "^1.1.0",


### PR DESCRIPTION
- Fixes color contrast issues with the default colors used in the stylesheets (found using ember-a11y-testing)
- Replaced div with labels
- Added enter action to focus input
- Fixed indentation in the blueprints to be compliant with ember-cli-template-lint
- Make all color variables in stylesheets overridable