### PR TITLE
Fix(freestyle-menu): Reset f queryParam in menu

### DIFF
--- a/addon/templates/components/freestyle-menu.hbs
+++ b/addon/templates/components/freestyle-menu.hbs
@@ -6,13 +6,13 @@
   </li>
   {{#each menu as |section|}}
     <li class="FreestyleMenu-item">
-      {{#link-to (query-params s=section.name ss=null) class="FreestyleMenu-itemLink"}}
+      {{#link-to (query-params f=null s=section.name ss=null) class="FreestyleMenu-itemLink"}}
         {{section.name}}
       {{/link-to}}
       {{#each section.subsections as |subsection|}}
         <ul class="FreestyleMenu-submenu">
           <li class="FreestyleMenu-submenuItem">
-            {{#link-to (query-params s=section.name ss=subsection.name) class="FreestyleMenu-submenuItemLink"}}
+            {{#link-to (query-params f=null s=section.name ss=subsection.name) class="FreestyleMenu-submenuItemLink"}}
               {{subsection.name}}
             {{/link-to}}
           </li>


### PR DESCRIPTION
@chrislopresto First of all this addon is amazing!

The PR fixes a minor bug. You can see it in action:
http://chrislopresto.github.io/ember-freestyle/?f=foo-normal&s=Foo%20Things&ss=Foo%20Subsection%20A

If you click on an item in the navigation a blank page is rendered. The PR fixes it by reseting the `f` queryParam.
