### PR TITLE
Support Less

### DIFF
--- a/app/styles/components/freestyle-annotation.less
+++ b/app/styles/components/freestyle-annotation.less
@@ -1,0 +1,4 @@
+.FreestyleAnnotation {
+  font-size: .9rem;
+  padding: 0 1rem;
+}

--- a/app/styles/components/freestyle-collection.less
+++ b/app/styles/components/freestyle-collection.less
@@ -1,0 +1,54 @@
+@FreestyleCollection-maxWidth: @FreestyleGuide-maxWidth;
+@FreestyleCollection-shadow1: rgba(0, 0, 0, .16);
+@FreestyleCollection-shadow2: rgba(0, 0, 0, .12);
+@FreestyleCollection-boxShadow: 0 2px 5px 0 @FreestyleCollection-shadow1, 0 2px 10px 0 @FreestyleCollection-shadow2;
+
+.FreestyleCollection {
+  max-width: @FreestyleCollection-maxWidth;
+
+  &-title {
+    font-weight: bold;
+    padding: 1rem 1rem 0;
+    text-transform: uppercase;
+  }
+
+  &-variantList {
+    background-color: @FreestyleGuide-color--background;
+    box-shadow: @FreestyleCollection-boxShadow;
+    color: @FreestyleGuide-color--foreground;
+    display: flex;
+    height: 48px;
+    list-style-type: none;
+    margin: 1rem;
+    overflow-x: auto;
+    overflow-y: hidden;
+    padding: 0;
+    position: relative;
+    white-space: nowrap;
+  }
+
+  &-variantListItem {
+    cursor: pointer;
+    display: block;
+    flex-grow: 1;
+    float: left;
+    font-size: 14px;
+    height: 48px;
+    letter-spacing: .8px;
+    line-height: 48px;
+    margin: 0;
+    min-width: 120px;
+    overflow: hidden;
+    padding: 0;
+    text-align: center;
+    text-overflow: ellipsis;
+    text-transform: uppercase;
+    width: 15%;
+
+    &:hover,
+    &--active {
+      border-bottom: solid 3px @FreestyleGuide-color--primary;
+      color: @FreestyleGuide-color--primary;
+    }
+  }
+}

--- a/app/styles/components/freestyle-guide.less
+++ b/app/styles/components/freestyle-guide.less
@@ -1,0 +1,110 @@
+// 1. Avoid the IE 10-11 `min-height` bug.
+// 2. Set `flex-shrink` to `0` to prevent some browsers from
+//    letting these items shrink to smaller than their content's default
+//    minimum size. See http://bit.ly/1Mn35US for details.
+// 3. Use `%` instead of `vh` since `vh` is buggy in older mobile Safari.
+
+@FreestyleGuide-maxWidth: 1200px;
+@FreestyleGuide-asideBackgroundColor: #fff;
+@FreestyleGuide-shadow1: rgba(0, 0, 0, .16);
+@FreestyleGuide-shadow2: rgba(0, 0, 0, .12);
+@FreestyleGuide-boxShadow: 0 2px 5px 0 @FreestyleGuide-shadow1, 0 2px 10px 0 @FreestyleGuide-shadow2;
+
+.FreestyleGuide {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 100vh;
+  min-width: 320px;
+
+  &-header,
+  &-footer {
+    display: flex;
+    flex: none;
+  }
+
+  &-header {
+    align-items: top;
+    border-bottom: solid 1px @FreestyleGuide-color--secondary;
+    padding: .5rem 1rem;
+  }
+
+  &-cta {
+    align-self: center;
+    cursor: pointer;
+    display: inline-block;
+    flex-basis: 20px;
+    font-size: 1.4rem;
+    text-align: center;
+  }
+
+  &-ctaIcon {
+    &:hover {
+      fill: @FreestyleGuide-color--primary;
+    }
+  }
+
+  &-titleContainer {
+    flex-grow: 1;
+    padding: 0 1rem;
+    text-align: center;
+  }
+
+  &-title {
+    font-size: 1.4rem;
+    font-weight: bold;
+
+    .freestyle-breakpoint(large, {
+      font-size: 1.9rem;
+    });
+  }
+
+  &-subtitle {
+    margin: 0 auto;
+  }
+
+  &-body {
+    background-color: @FreestyleGuide-color--background;
+    display: flex;
+    flex: 1 0 auto;
+    flex-direction: column;
+
+    .freestyle-breakpoint(large, {
+      flex-direction: row;
+    });
+  }
+
+  &-content {
+    margin-top: 1.5rem;
+
+    .freestyle-breakpoint(large, {
+      flex: 1;
+      margin: 0;
+    });
+  }
+
+  &-nav {
+    background-color: @FreestyleGuide-color--background;
+    order: -1;
+    padding: 1rem;
+
+    .freestyle-breakpoint(large, {
+      border-right: solid 1px @FreestyleGuide-color--secondary;
+      flex: 0 0 18rem;
+    });
+  }
+
+  &-aside {
+    background: @FreestyleGuide-asideBackgroundColor;
+    box-shadow: @FreestyleGuide-boxShadow;
+    margin-right: .5rem;
+    order: -2;
+    position: fixed;
+    right: .5rem;
+
+    .freestyle-breakpoint(large, {
+      border-left: solid 1px @FreestyleGuide-color--secondary;
+      order: 1;
+    });
+  }
+}

--- a/app/styles/components/freestyle-menu.less
+++ b/app/styles/components/freestyle-menu.less
@@ -1,0 +1,32 @@
+.FreestyleMenu {
+  font-size: 14px;
+  list-style: none;
+  padding-left: 1rem;
+
+  &-item,
+  &-submenuItem {
+    padding-top: .6rem;
+    text-transform: uppercase;
+  }
+
+  &-itemLink,
+  &-submenuItemLink {
+    color: @FreestyleGuide-color--foreground;
+    text-decoration: none;
+
+    &.active {
+      color: @FreestyleGuide-color--primary;
+      text-decoration: none;
+    }
+
+    &:hover {
+      color: @FreestyleGuide-color--accent;
+      text-decoration: none;
+    }
+  }
+
+  &-submenu {
+    list-style: none;
+    padding-left: 1rem;
+  }
+}

--- a/app/styles/components/freestyle-note.less
+++ b/app/styles/components/freestyle-note.less
@@ -1,0 +1,6 @@
+.FreestyleNote {
+  // This component is not rendered directly. Its content is the source of
+  // snippets that will be rendered by a freestyle-notes component in
+  // a freestyle-usage component.
+  display: none;
+}

--- a/app/styles/components/freestyle-notes.less
+++ b/app/styles/components/freestyle-notes.less
@@ -9,31 +9,31 @@
   }
 
   &--tomorrow-night {
-    @import '../ember-freestyle/highlight.js/tomorrow-night';
+    @import (multiple) '../ember-freestyle/highlight.js/tomorrow-night';
   }
 
   &--zenburn {
-    @import '../ember-freestyle/highlight.js/zenburn';
+    @import (multiple) '../ember-freestyle/highlight.js/zenburn';
   }
 
   &--hybrid {
-    @import '../ember-freestyle/highlight.js/hybrid';
+    @import (multiple) '../ember-freestyle/highlight.js/hybrid';
   }
 
   &--atelier-cave-dark {
-    @import '../ember-freestyle/highlight.js/atelier-cave-dark';
+    @import (multiple) '../ember-freestyle/highlight.js/atelier-cave-dark';
   }
 
   &--solarized-light {
-    @import '../ember-freestyle/highlight.js/solarized-light';
+    @import (multiple) '../ember-freestyle/highlight.js/solarized-light';
   }
 
   &--docco {
-    @import '../ember-freestyle/highlight.js/docco';
+    @import (multiple) '../ember-freestyle/highlight.js/docco';
   }
 
   &--monokai-sublime {
-    @import '../ember-freestyle/highlight.js/monokai-sublime';
+    @import (multiple) '../ember-freestyle/highlight.js/monokai-sublime';
   }
 
   h1,

--- a/app/styles/components/freestyle-notes.less
+++ b/app/styles/components/freestyle-notes.less
@@ -1,0 +1,57 @@
+.FreestyleNotes {
+  pre {
+    font-size: .8rem;
+    margin-top: 0;
+
+    &.hljs {
+      padding: .5rem 1rem;
+    }
+  }
+
+  &--tomorrow-night {
+    @import '../ember-freestyle/highlight.js/tomorrow-night';
+  }
+
+  &--zenburn {
+    @import '../ember-freestyle/highlight.js/zenburn';
+  }
+
+  &--hybrid {
+    @import '../ember-freestyle/highlight.js/hybrid';
+  }
+
+  &--atelier-cave-dark {
+    @import '../ember-freestyle/highlight.js/atelier-cave-dark';
+  }
+
+  &--solarized-light {
+    @import '../ember-freestyle/highlight.js/solarized-light';
+  }
+
+  &--docco {
+    @import '../ember-freestyle/highlight.js/docco';
+  }
+
+  &--monokai-sublime {
+    @import '../ember-freestyle/highlight.js/monokai-sublime';
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  p {
+    padding: 0 1rem;
+  }
+
+  // Appropriating h6 as snippet title
+  h6 {
+    font-size: .7rem;
+    font-weight: bold;
+    margin: 0;
+    padding: .5rem 1rem .2rem;
+    text-transform: uppercase;
+  }
+}

--- a/app/styles/components/freestyle-palette-item.less
+++ b/app/styles/components/freestyle-palette-item.less
@@ -1,0 +1,45 @@
+/* BEGIN-FREESTYLE-USAGE fpi:notes
+# Markdown Notes In SCSS!
+
+Hey look... these are `markdown` notes:
+
+- coming from scss
+- looking nice
+
+END-FREESTYLE-USAGE */
+
+// BEGIN-FREESTYLE-USAGE fpi
+@freestylePaletteItemBorderColor: #cecece;
+@FreestylePaletteItem-backgroundColor: #fff;
+@FreestylePaletteItem-color: #2f4f4f;
+
+.FreestylePaletteItem {
+  border: solid 1px @freestylePaletteItemBorderColor;
+  display: inline-block;
+  margin: 0 5px 5px 0;
+
+  &-color {
+    height: 90px;
+    width: 160px;
+  }
+
+  &-info {
+    background-color: @FreestylePaletteItem-backgroundColor;
+    border-top: solid 1px @freestylePaletteItemBorderColor;
+    padding: 5px;
+  }
+
+  &-hex {
+    font-size: 12px;
+    font-weight: bold;
+    margin-bottom: 0;
+  }
+
+  &-name {
+    color: @FreestylePaletteItem-color;
+    font-size: 11px;
+    margin-top: 0;
+  }
+
+}
+// END-FREESTYLE-USAGE

--- a/app/styles/components/freestyle-palette.less
+++ b/app/styles/components/freestyle-palette.less
@@ -1,0 +1,13 @@
+.FreestylePalette {
+  &-title {
+    font-size: 1.4rem;
+    font-weight: bold;
+    padding-bottom: 2px;
+    padding-top: 10px;
+  }
+
+  &-description {
+    font-size: .8rem;
+    padding-bottom: 5px;
+  }
+}

--- a/app/styles/components/freestyle-section.less
+++ b/app/styles/components/freestyle-section.less
@@ -1,0 +1,18 @@
+@FreestyleSection-borderColor: #ccc;
+
+.FreestyleSection {
+  &-name {
+    // TODO: Calculate max-width from @FreestyleGuide-maxWidth
+    border-bottom: solid 1px @FreestyleSection-borderColor;
+    font-size: 1.5rem;
+    font-weight: bold;
+    margin: 0 1rem;
+    max-width: calc(1200px - 1rem);
+    padding: 1rem 0 .4rem;
+    text-transform: uppercase;
+  }
+
+  &--hidden {
+    display: none;
+  }
+}

--- a/app/styles/components/freestyle-snippet.less
+++ b/app/styles/components/freestyle-snippet.less
@@ -1,0 +1,8 @@
+.FreestyleSnippet {
+  &-title {
+    font-size: .7rem;
+    font-weight: bold;
+    padding: .5rem 1rem .2rem;
+    text-transform: uppercase;
+  }
+}

--- a/app/styles/components/freestyle-subsection.less
+++ b/app/styles/components/freestyle-subsection.less
@@ -1,0 +1,8 @@
+.FreestyleSubsection {
+  &-name {
+    font-size: 1.3rem;
+    margin: 0 1rem;
+    padding: .8rem 0 .4rem;
+    text-transform: uppercase;
+  }
+}

--- a/app/styles/components/freestyle-typeface.less
+++ b/app/styles/components/freestyle-typeface.less
@@ -1,0 +1,11 @@
+.FreestyleTypeface {
+  &-previewHero {
+    font-size: 140px;
+    line-height: 1.05;
+  }
+
+  &-previewSample {
+    font-size: 15px;
+    margin: 0;
+  }
+}

--- a/app/styles/components/freestyle-usage-controls.less
+++ b/app/styles/components/freestyle-usage-controls.less
@@ -1,0 +1,54 @@
+@FreestyleUsageControls-backgroundColor: #fff;
+@FreestyleUsageControls-shadow1: rgba(0, 0, 0, .16);
+@FreestyleUsageControls-shadow2: rgba(0, 0, 0, .12);
+@FreestyleUsageControls-boxShadow: 0 2px 5px 0 @FreestyleUsageControls-shadow1, 0 2px 10px 0 @FreestyleUsageControls-shadow2;
+
+.FreestyleUsageControls {
+  background: @FreestyleUsageControls-backgroundColor;
+  font-size: .9rem;
+  padding: 1rem;
+  text-align: left;
+  width: 200px;
+
+  &-header {
+    color: @FreestyleGuide-color--primary;
+    font-weight: bold;
+    margin-bottom: .3rem;
+    text-transform: uppercase;
+  }
+
+  &-item {
+    align-items: baseline;
+    display: flex;
+
+    &--focus {
+      padding-top: .6rem;
+    }
+  }
+
+  &-itemControl {
+    cursor: pointer;
+    padding-right: .1rem;
+  }
+
+  &-itemLabel {
+    font-size: .8rem;
+  }
+
+  &-input {
+    &--focus {
+      margin-bottom: .2rem;
+    }
+  }
+
+  &-button {
+    background-color: @FreestyleGuide-color--primary;
+    border: 0;
+    box-shadow: @FreestyleUsageControls-boxShadow;
+    color: @FreestyleGuide-color--background;
+    cursor: pointer;
+    font-size: .6rem;
+    padding: .4rem 1rem;
+    text-transform: uppercase;
+  }
+}

--- a/app/styles/components/freestyle-usage.less
+++ b/app/styles/components/freestyle-usage.less
@@ -33,31 +33,31 @@
     }
 
     &--tomorrow-night {
-      @import '../ember-freestyle/highlight.js/tomorrow-night';
+      @import (multiple) '../ember-freestyle/highlight.js/tomorrow-night';
     }
 
     &--zenburn {
-      @import '../ember-freestyle/highlight.js/zenburn';
+      @import (multiple) '../ember-freestyle/highlight.js/zenburn';
     }
 
     &--hybrid {
-      @import '../ember-freestyle/highlight.js/hybrid';
+      @import (multiple) '../ember-freestyle/highlight.js/hybrid';
     }
 
     &--atelier-cave-dark {
-      @import '../ember-freestyle/highlight.js/atelier-cave-dark';
+      @import (multiple) '../ember-freestyle/highlight.js/atelier-cave-dark';
     }
 
     &--solarized-light {
-      @import '../ember-freestyle/highlight.js/solarized-light';
+      @import (multiple) '../ember-freestyle/highlight.js/solarized-light';
     }
 
     &--docco {
-      @import '../ember-freestyle/highlight.js/docco';
+      @import (multiple) '../ember-freestyle/highlight.js/docco';
     }
 
     &--monokai-sublime {
-      @import '../ember-freestyle/highlight.js/monokai-sublime';
+      @import (multiple) '../ember-freestyle/highlight.js/monokai-sublime';
     }
   }
 

--- a/app/styles/components/freestyle-usage.less
+++ b/app/styles/components/freestyle-usage.less
@@ -1,0 +1,87 @@
+@FreestyleUsage-borderColor: #cecece;
+@FreestyleUsage-maxWidth: @FreestyleGuide-maxWidth;
+
+.FreestyleUsage {
+  max-width: @FreestyleUsage-maxWidth;
+
+  &-title {
+    font-weight: bold;
+    padding: 1rem 1rem 0;
+    text-transform: uppercase;
+  }
+
+  &-notes {
+    font-size: .9rem;
+  }
+
+  &-rendered {
+    padding: 1rem;
+  }
+
+  &-usage {
+    padding-bottom: 10px;
+  }
+
+  &-snippet {
+    pre {
+      font-size: .8rem;
+      margin-top: 0;
+
+      &.hljs {
+        padding: .5rem 1rem;
+      }
+    }
+
+    &--tomorrow-night {
+      @import '../ember-freestyle/highlight.js/tomorrow-night';
+    }
+
+    &--zenburn {
+      @import '../ember-freestyle/highlight.js/zenburn';
+    }
+
+    &--hybrid {
+      @import '../ember-freestyle/highlight.js/hybrid';
+    }
+
+    &--atelier-cave-dark {
+      @import '../ember-freestyle/highlight.js/atelier-cave-dark';
+    }
+
+    &--solarized-light {
+      @import '../ember-freestyle/highlight.js/solarized-light';
+    }
+
+    &--docco {
+      @import '../ember-freestyle/highlight.js/docco';
+    }
+
+    &--monokai-sublime {
+      @import '../ember-freestyle/highlight.js/monokai-sublime';
+    }
+  }
+
+  &--inline {
+    border-bottom: 0;
+    display: inline-block;
+    margin-bottom: 0;
+    padding-bottom: 0;
+    width: 100%;
+
+    .freestyle-breakpoint(large, {
+      max-width: inherit;
+      width: auto;
+    });
+  }
+
+  &-focusCta {
+    cursor: pointer;
+    fill: @FreestyleGuide-color--secondary;
+    position: relative;
+    top: 1px;
+
+    &:hover {
+      fill: @FreestyleGuide-color--primary;
+    }
+  }
+}

--- a/app/styles/components/freestyle-variant.less
+++ b/app/styles/components/freestyle-variant.less
@@ -1,0 +1,5 @@
+.FreestyleVariant {
+  &--inline {
+    display: inline-block;
+  }
+}

--- a/app/styles/ember-freestyle.less
+++ b/app/styles/ember-freestyle.less
@@ -1,0 +1,32 @@
+// TODO: Replace with actual breakpoint system
+@FreestyleBreakpoint--large: 600px;
+
+.freestyle-breakpoint(@name: 'large', @content) {
+  @BreakpointVariable: %('FreestyleBreakpoint--%s', @name);
+  @media (min-width: @@BreakpointVariable) {
+    @content();
+  }
+};
+
+// Default Ember Freestyle Palette
+@FreestyleGuide-color--primary: #0d47a1;
+@FreestyleGuide-color--accent: #ffc107;
+@FreestyleGuide-color--secondary: #b6b6b6;
+@FreestyleGuide-color--foreground: #212121;
+@FreestyleGuide-color--background: #fff;
+
+@import 'components/freestyle-guide';
+@import 'components/freestyle-collection';
+@import 'components/freestyle-variant';
+@import 'components/freestyle-annotation';
+@import 'components/freestyle-usage-controls';
+@import 'components/freestyle-palette';
+@import 'components/freestyle-palette-item';
+@import 'components/freestyle-note';
+@import 'components/freestyle-notes';
+@import 'components/freestyle-usage';
+@import 'components/freestyle-section';
+@import 'components/freestyle-subsection';
+@import 'components/freestyle-menu';
+@import 'components/freestyle-snippet';
+@import 'components/freestyle-typeface';

--- a/blueprints/ember-freestyle/files/__root__/app/styles/app.less
+++ b/blueprints/ember-freestyle/files/__root__/app/styles/app.less
@@ -1,0 +1,1 @@
+@import 'ember-freestyle';

--- a/blueprints/ember-freestyle/index.js
+++ b/blueprints/ember-freestyle/index.js
@@ -1,3 +1,4 @@
+/* jshint node: true */
 var path = require('path');
 
 module.exports = {
@@ -24,5 +25,25 @@ module.exports = {
     ];
 
     return this.addBowerPackagesToProject(bowerPackages);
+  },
+
+  files: function() {
+    var files = this._super.call(this);
+    if (!this.project) {
+      return files;
+    }
+
+    var allowedStyleFiles = {
+      scss: !!(this.project.findAddonByName('ember-cli-sass')),
+      less: !!(this.project.findAddonByName('ember-cli-less'))
+    };
+    var supportedPreprocessors = Object.keys(allowedStyleFiles);
+
+    function filterFilesByAvailableProproessor(file) {
+      var styleType = path.extname(file).substring(1);
+      return supportedPreprocessors.indexOf(styleType) === -1 || allowedStyleFiles[styleType] === true;
+    }
+
+    return files.filter(filterFilesByAvailableProproessor);
   }
 };

--- a/index.js
+++ b/index.js
@@ -56,9 +56,10 @@ module.exports = {
       srcDir: '/styles',
       destDir: '/app/styles/ember-freestyle/highlight.js'
     });
-    highlightJsTree = stew.rename(highlightJsTree, '.css', '.scss');
+    var highLightJsScss = stew.rename(highlightJsTree, '.css', '.scss');
+    var highLightJsLess = stew.rename(highlightJsTree, '.css', '.less');
 
-    return mergeTrees([highlightJsTree, tree], {
+    return mergeTrees([highLightJsScss, highLightJsLess, tree], {
       overwrite: true
     });
   },
@@ -83,6 +84,6 @@ module.exports = {
   },
 
   isDevelopingAddon: function() {
-    return false;
+    return true;
   }
 };

--- a/index.js
+++ b/index.js
@@ -84,6 +84,6 @@ module.exports = {
   },
 
   isDevelopingAddon: function() {
-    return true;
+    return false;
   }
 };


### PR DESCRIPTION
I wanted to play with this addon (nice piece of work! 👍 ) a bit with an existing app, but that is based on Less instead of Sass. This has already been addressed in #15. I figured out it would not be too hard to add Less support, so here we go...

All the .scss files have been "translated" by hand to .less, which was quite easy as the features used so far did not require much translation (the variable syntax is a slightly different as well as the breakpoint mixin, other changes were not required).

The default blueprint checks which preprocessor (ember-cli-sass or ember-cli-less) is available and only installs the corresponding styles/app.xxxx file!

Hope you find this useful. The only downside is that changing the styles in the future requires updates for the Sass and Less files as well now. But again, the differences are so minor, this should be neglectable. I can help though if required! ;)