### PR TITLE
Use `includes` instead of `contains`, which is deprecated in ember 2.8+

### DIFF
--- a/addon/components/freestyle-collection.js
+++ b/addon/components/freestyle-collection.js
@@ -24,7 +24,7 @@ export default Ember.Component.extend({
   registerVariant(variantKey) {
     Ember.run.next(() => {
       let variants = this.get('variants') || Ember.A(['all']);
-      if (!variants.contains(variantKey)) {
+      if (!variants.includes(variantKey)) {
         variants.pushObject(variantKey);
       }
       this.set('variants', variants);

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "ember-cli-babel": "^5.1.6",
     "ember-cli-htmlbars": "^1.0.3",
     "ember-remarkable": "chrislopresto/ember-remarkable#highlightjs-css-compatibility-3.2.0",
+    "ember-runtime-enumerable-includes-polyfill": "^1.0.4",
     "ember-truth-helpers": "1.2.0",
     "es6-promise": "^3.1.2",
     "glob": "^6.0.4",


### PR DESCRIPTION
Fixes #91