### PR TITLE
Update ember-truth-helpers to 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "ember-cli-htmlbars": "^1.0.3",
     "ember-remarkable": "chrislopresto/ember-remarkable#highlightjs-css-compatibility-3.2.0",
     "ember-runtime-enumerable-includes-polyfill": "^1.0.4",
-    "ember-truth-helpers": "1.2.0",
+    "ember-truth-helpers": "^1.3.0",
     "es6-promise": "^3.1.2",
     "glob": "^6.0.4",
     "highlight.js": "^9.3.0"


### PR DESCRIPTION
This kills [npm package published with engine: "ember-cli-app-version"](https://github.com/jmurphyau/ember-truth-helpers/issues/46).