### PR TITLE
Fix 'calling set on destroyed object' error

### DIFF
--- a/addon/components/freestyle-collection.js
+++ b/addon/components/freestyle-collection.js
@@ -23,6 +23,7 @@ export default Ember.Component.extend({
 
   registerVariant(variantKey) {
     Ember.run.next(() => {
+      if (this.isDestroyed) { return; }
       let variants = this.get('variants') || Ember.A(['all']);
       if (!variants.includes(variantKey)) {
         variants.pushObject(variantKey);


### PR DESCRIPTION
When navigating away from a style guide (especially in an automated testing context) this run.next can sometimes fire after the component is destroyed. This prevents that from happening.