### PR TITLE
[WIP] Remove all addon artefacts from production build

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "repository": "https://github.com/chrislopresto/ember-freestyle.git",
   "engines": {
-    "node": ">= 0.10.0"
+    "node": ">= 4.0.0"
   },
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
Here is something to solve #31. Still not ready to merge, needs at least some review, documentation and maybe some acceptance tests.

It introduces a new option `enabled` for your `ember-cli-build.js`, which defaults to false for a production build. So when this is false, it does the following:

* everything from the addons `app` folder is removed from build, so none of the components are available
* it does not import the other js dependencies (remarkable + highlight.js)
* it replaces all `app/styles` files with an empty file. This is to not break any `@import` statements from the app's `app.scss`, but still not add any styleguide related styles to the app's CSS payload

What it does *not*:
* it does not remove the addons included as deps from `package.json`, namely `ember-remarkable` and `ember-truth-helpers`. This is because I found no way to do that, see https://github.com/chrislopresto/ember-freestyle/compare/master...simonihmig:disable-production-build?expand=1#diff-168726dbe96b3ce427e7fedce31bb0bcR85. Maybe someone has an idea about this? 
* it does not remove the 'freestyle'  controller and template from the app itself. I think it is actually not a good idea to do that from the addon, as these files are in the realm of the user's app, so the addon should not tinker with them. Also we cannot know for sure where they are, e.g. we decided to put them into the app under a 'styleguide' route instead of 'ember-freestyle'. As @kellyselden suggested in #31, this can be easily accomplished using his `ember-cli-funnel`. Did that for our app, works just fine. We can add documentation to make this easy for the user.

This worked so far well for our app, **reducing the JS payload by about 775kB**! (uncompressed) 

So, if this looks right for you, I can add some pieces to the docs and add some tests.