### PR TITLE
Update to ember-remarkable 3.6.0

### DIFF
--- a/addon/components/freestyle-md-text.js
+++ b/addon/components/freestyle-md-text.js
@@ -1,0 +1,15 @@
+import Ember from 'ember';
+import MDTextComponent from 'ember-remarkable/components/md-text';
+
+const { computed } = Ember;
+
+export default MDTextComponent.extend({
+  parsedMarkdownUnsafe: computed('text', 'html', 'typographer', 'linkify', 'linkTarget', function () {
+    let html = this._super(...arguments);
+    // HACK: Add hljs class for compatibility with latest highlight.js CSS
+    //       This should really be done with a `custom_fence` rule as
+    //       described here:
+    //       https://github.com/jonschlinkert/remarkable/issues/131
+    return html.replace(/<pre>/g, '<pre class="hljs">');
+  })
+});

--- a/addon/templates/components/freestyle-notes.hbs
+++ b/addon/templates/components/freestyle-notes.hbs
@@ -1,3 +1,3 @@
 <div class="FreestyleNotes FreestyleNotes--{{theme}}">
-  {{md-text text=text class="FreestyleNotes-content"}}
+  {{freestyle-md-text text=text class="FreestyleNotes-content"}}
 </div>

--- a/app/components/freestyle-md-text.js
+++ b/app/components/freestyle-md-text.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-freestyle/components/freestyle-md-text';

--- a/index.js
+++ b/index.js
@@ -65,6 +65,7 @@ module.exports = {
         'monokai-sublime.css'
       ]
     });
+    highlightJsTree = stew.log(highlightJsTree);
     highlightJsTree = stew.rename(highlightJsTree, '.css', '.scss');
 
     return mergeTrees([highlightJsTree, addonStyles]);
@@ -81,12 +82,7 @@ module.exports = {
         type: 'vendor',
         exports: { 'remarkable': ['default'] }
       });
-      target.import('vendor/ember-remarkable/highlightjs-shim.js', {
-        type: 'vendor',
-        exports: { 'hljs': ['default'] }
-      });
     }
-
   },
 
   isDevelopingAddon: function() {

--- a/index.js
+++ b/index.js
@@ -65,7 +65,6 @@ module.exports = {
         'monokai-sublime.css'
       ]
     });
-    highlightJsTree = stew.log(highlightJsTree);
     highlightJsTree = stew.rename(highlightJsTree, '.css', '.scss');
 
     return mergeTrees([highlightJsTree, addonStyles]);

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ember-cli-babel": "^6.0.0",
     "ember-cli-htmlbars": "^1.3.0",
     "ember-cli-sass": "6.1.2",
-    "ember-remarkable": "chrislopresto/ember-remarkable#highlightjs-css-compatibility-3.2.0",
+    "ember-remarkable": "chrislopresto/ember-remarkable#safe-config",
     "ember-runtime-enumerable-includes-polyfill": "^1.0.4",
     "ember-truth-helpers": "^1.3.0",
     "es6-promise": "^3.1.2",


### PR DESCRIPTION
NOTE: Currently on a fork until
https://github.com/johnotander/ember-remarkable/pull/34 is merged

This commit pulls the injection of the "hljs" class selector into a
freestyle-md-text component that extends md-text from ember-remarkable.
Prior to this, this hack had been done on an ember-remarkable fork I
was maintaining. It's nice to be rid of that bit of silliness.