### PR TITLE
Change to underscore delimiter for Windows-friendly snippet names

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,13 +145,13 @@ By default, variants will be stacked. If you wish to view variants side by side,
 
 _TODO:_ [Simplify Technique for Including Notes](https://github.com/chrislopresto/ember-freestyle/issues/61)
 
-Use the `freestyle-note` component to add a markdown note for a specific `freestyle-usage`. Note that the `freestyle-note` slug must match the `freestyle-usage` slug followed by `:notes`.
+Use the `freestyle-note` component to add a markdown note for a specific `freestyle-usage`. Note that the `freestyle-note` slug must match the `freestyle-usage` slug followed by `_notes`.
 
 ```hbs
 {{#freestyle-usage "globally-unique-slug" title="Title To Display In Style Guide"}}
   {{x-foo propa="aaa" propb="bbb"}}
 {{/freestyle-usage}}
-{{#freestyle-note "globally-unique-slug:notes"}}
+{{#freestyle-note "globally-unique-slug_notes"}}
   # Contextual Markdown Note for x-foo
 
   You can write helpful _markdown_ notes explaining how the

--- a/addon/components/freestyle-snippet.js
+++ b/addon/components/freestyle-snippet.js
@@ -52,7 +52,7 @@ export default Ember.Component.extend({
   },
 
   language: computed('name', function() {
-    if (this.get('name').indexOf(':notes') >= 0) {
+    if (this.get('name').indexOf('_notes') >= 0) {
       return 'markdown';
     }
 

--- a/addon/styles/components/freestyle-palette-item.scss
+++ b/addon/styles/components/freestyle-palette-item.scss
@@ -1,4 +1,4 @@
-/* BEGIN-FREESTYLE-USAGE fpi:notes
+/* BEGIN-FREESTYLE-USAGE fpi_notes
 # Markdown Notes In SCSS!
 
 Hey look... these are `markdown` notes:

--- a/blueprints/ember-freestyle/files/__root__/app/controllers/freestyle.js
+++ b/blueprints/ember-freestyle/files/__root__/app/controllers/freestyle.js
@@ -6,7 +6,7 @@ const { inject } = Ember;
 export default FreestyleController.extend({
   emberFreestyle: inject.service(),
 
-  /* BEGIN-FREESTYLE-USAGE fp:notes
+  /* BEGIN-FREESTYLE-USAGE fp_notes
 ### A few notes regarding freestyle-palette
 
 - Accepts a colorPalette POJO like the one found in the freestyle.js blueprint controller

--- a/freestyle-usage-snippet-finder.js
+++ b/freestyle-usage-snippet-finder.js
@@ -55,15 +55,15 @@ function extractHbsComponentSnippets(fileContent, componentName, ui) {
         inside = m[0].indexOf('}}') >= 0; // curlies closed }}
         name = m[1];
         // TODO: Cleanup freestyle-notes vs freestyle-usage disambiguation here
-        if (name.indexOf(':notes') >= 0) {
+        if (name.indexOf('_notes') >= 0) {
           if (output[name]) {
             ui.writeLine('ember-freestyle detected multiple instances of the freestyle-note slug "' + name +'"');
           }
         } else {
-          if (output[name + ':usage']) {
+          if (output[name + '_usage']) {
             ui.writeLine('ember-freestyle detected multiple instances of the freestyle-usage slug "' + name +'"');
           }
-          name += ':usage';
+          name += '_usage';
         }
       }
     }
@@ -117,8 +117,7 @@ SnippetFinder.prototype.write = function (readTree, destDir) {
       var commentSnippets = extractCommentSnippets(fs.readFileSync(filename, 'utf-8'));
       var snippets = naiveMerge(componentSnippets, commentSnippets);
       for (var name in snippets){
-        var windowsFriendlyName = name.replace(":notes", "_notes").replace(":usage", "_usage"); // replace : in order to have windows friendly filenames
-        fs.writeFileSync(path.join(destDir, windowsFriendlyName)+path.extname(filename),
+        fs.writeFileSync(path.join(destDir, name)+path.extname(filename),
                          snippets[name]);
       }
     });

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -7,7 +7,7 @@ export default FreestyleController.extend({
   emberFreestyle: inject.service(),
   showCode: computed.alias('emberFreestyle.showCode'),
 
-  /* BEGIN-FREESTYLE-USAGE fpi:notes
+  /* BEGIN-FREESTYLE-USAGE fpi_notes
 ### A few notes regarding freestyle-palette-item
 
 - Accepts a color object

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -17,7 +17,7 @@
           component to write notes in html.
         </p>
         {{/freestyle-annotation}}
-          {{#freestyle-note 'foo-normal:notes'}}
+          {{#freestyle-note 'foo-normal_notes'}}
   #### Another Note About Normal
 
   This comment is coming from a `freestyle-note` component. Use the `freestyle-note` component


### PR DESCRIPTION
This fixes up a git snafu. I could have sworn this changeset made it into v0.2.14. Anyway, better late than never.

<img width="1218" alt="screenshot 2017-05-03 22 44 52" src="https://cloud.githubusercontent.com/assets/93691/25689045/25ef0854-3052-11e7-8bd4-a05deec1fcda.png">

Resolves https://github.com/chrislopresto/ember-freestyle/issues/99