### PR TITLE
Remove wip status from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@ Ember Freestyle is an Ember addon that allows you to quickly create a component 
 
 [Documentation found here](http://ember-freestyle.com/)
 
-*This is a work in progress. Collaboration is welcomed.*
-
 ## Live Demo
 
 http://chrislopresto.github.io/ember-freestyle/


### PR DESCRIPTION
emberobserver.com lists this addon as "wip":
![image](https://cloud.githubusercontent.com/assets/1325249/25713418/eb2d8346-30f4-11e7-97a3-7171e8941f27.png)

So I removed this from the Readme, to allow having a score on emberobserver!