### PR TITLE
Fix horizontal scroll on content

### DIFF
--- a/addon/styles/components/freestyle-guide.scss
+++ b/addon/styles/components/freestyle-guide.scss
@@ -76,6 +76,7 @@ $FreestyleGuide-boxShadow: 0 2px 5px 0 $FreestyleGuide-shadow1, 0 2px 10px 0 $Fr
 
   &-content {
     margin-top: 1.5rem;
+    overflow: auto;
 
     @include freestyle-breakpoint(large) {
       flex: 1;


### PR DESCRIPTION
I noticed that the `FreestyleGuide-content` area of the style guide can occasionally stretch beyond the bounds of the page.
This happens especially when a component may have large amounts of text or when a `freestyle-collection` of many items is set to `inline=true`.

By setting `overflow: auto` on this selector, the child elements better observe the given space by the master detail flex relation between `FreestyleGuide-content` and its parent instead of trying to extend beyond the bounds and preventing shrink.