### PR TITLE
Replace broccoli-unwatched-tree with broccoli-source

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var flatiron = require('broccoli-flatiron');
 var freestyleUsageSnippetFinder = require('./freestyle-usage-snippet-finder');
 
 var Funnel = require('broccoli-funnel');
-var unwatchedTree  = require('broccoli-unwatched-tree');
+var UnwatchedDir = require('broccoli-source').UnwatchedDir;
 
 module.exports = {
   name: 'ember-freestyle',
@@ -52,7 +52,7 @@ module.exports = {
   treeForAddonStyles: function() {
     var addonStyles = new Funnel(path.join(__dirname, 'addon/styles'));
 
-    var highlightJsTree = new Funnel(unwatchedTree(path.dirname(require.resolve('highlight.js/package.json'))), {
+    var highlightJsTree = new Funnel(new UnwatchedDir(path.dirname(require.resolve('highlight.js/package.json'))), {
       srcDir: '/styles',
       destDir: '/ember-freestyle/highlight.js',
       files: [

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "broccoli-funnel": "^1.0.1",
     "broccoli-merge-trees": "^2.0.0",
     "broccoli-stew": "^1.2.0",
-    "broccoli-unwatched-tree": "^0.1.1",
+    "broccoli-source": "^1.1.0",
     "broccoli-writer": "^0.1.1",
     "ember-cli-babel": "^6.0.0",
     "ember-cli-htmlbars": "^1.3.0",


### PR DESCRIPTION
broccoli-unwatched-tree is deprecated, replaced with the functionality of broccoli-source. Anybody who is using Ember Freestyle can't build their Ember CLI application right now because of https://github.com/rwjblue/broccoli-unwatched-tree/issues/4 -- but since broccoli-unwatched-tree is deprecated, it should be replaced by broccoli-source.

Fixes #125 

Supersedes #126 