### PR TITLE
Yielded Component API

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,19 +124,19 @@ By default, variants will be stacked. If you wish to view variants side by side,
     {{#freestyle-usage "foo-foo-no-num" title="Information"}}
       {{foo-foo title="Information"}}
     {{/freestyle-usage}}
-  {{/freestyle-variant}}
+  {{/collection.variant}}
 
   {{#collection.variant key="with-num"}}
     {{#freestyle-usage "foo-foo-people" title="People"}}
       {{foo-foo title="People" num=55}}
     {{/freestyle-usage}}
-  {{/freestyle-variant}}
+  {{/collection.variant}}
 
   {{#collection.variant key="with-icon"}}
     {{#freestyle-usage "foo-foo-twitter" title="Twitter"}}
       {{foo-foo title="Twitter" icon="twitter"}}
     {{/freestyle-usage}}
-  {{/freestyle-variant}}
+  {{/collection.variant}}
 {{/freestyle-collection}}
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Ember Freestyle 
+# Ember Freestyle
 
 [![Build Status](https://travis-ci.org/chrislopresto/ember-freestyle.svg?branch=master)](https://travis-ci.org/chrislopresto/ember-freestyle)
-[![npm version](https://badge.fury.io/js/ember-freestyle.svg)](https://badge.fury.io/js/ember-freestyle) 
+[![npm version](https://badge.fury.io/js/ember-freestyle.svg)](https://badge.fury.io/js/ember-freestyle)
 ![Download count all time](https://img.shields.io/npm/dt/ember-freestyle.svg)
 [![Ember Observer Score](http://emberobserver.com/badges/ember-freestyle.svg)](http://emberobserver.com/addons/ember-freestyle)
 
@@ -86,18 +86,18 @@ Optionally divide your style guide sections into subsections using the `freestyl
 
 ```hbs
 {{#freestyle-guide title="My Living Style Guide" subtitle="Showcasing My App's Components"}}
-  {{#freestyle-section name='Visual Style' as |fsg|}}
-    {{#fsg.subsection name='Typography'}}
-      {{#freestyle-usage 'visual-style-typography-foo' title='Foo Typography'}}
+  {{#freestyle-section name="Visual Style" as |section|}}
+    {{#section.subsection name="Typography"}}
+      {{#freestyle-usage "visual-style-typography-foo" title="Foo Typography"}}
         {{x-foo-typography}}
       {{/freestyle-usage}}
-    {{/fsg.subsection}}
+    {{/section.subsection}}
 
-    {{#fsg.subsection name='Colors'}}
-      {{#freestyle-usage 'visual-style-colors-fie' title='Fie Colors'}}
+    {{#section.subsection name="Colors"}}
+      {{#freestyle-usage "visual-style-colors-fie" title='Fie Colors'}}
         {{x-fie-colors}}
       {{/freestyle-usage}}
-    {{/fsg.subsection}}
+    {{/section.subsection}}
   {{/freestyle-section}}
 {{/freestyle-guide}}
 ```
@@ -119,20 +119,20 @@ By default, variants will be stacked. If you wish to view variants side by side,
 `freestyle-collection` to true.
 
 ```hbs
-{{#freestyle-collection title='Foo Component In Every State' defaultKey='with-icon' inline=true as |collection|}}
-  {{#freestyle-variant collection=collection key='no-num'}}
+{{#freestyle-collection title="Foo Component In Every State" defaultKey="with-icon" inline=true as |collection|}}
+  {{#collection.variant key="no-num"}}
     {{#freestyle-usage "foo-foo-no-num" title="Information"}}
       {{foo-foo title="Information"}}
     {{/freestyle-usage}}
   {{/freestyle-variant}}
 
-  {{#freestyle-variant collection=collection key='with-num'}}
+  {{#collection.variant key="with-num"}}
     {{#freestyle-usage "foo-foo-people" title="People"}}
       {{foo-foo title="People" num=55}}
     {{/freestyle-usage}}
   {{/freestyle-variant}}
 
-  {{#freestyle-variant collection=collection key='with-icon'}}
+  {{#collection.variant key="with-icon"}}
     {{#freestyle-usage "foo-foo-twitter" title="Twitter"}}
       {{foo-foo title="Twitter" icon="twitter"}}
     {{/freestyle-usage}}
@@ -195,7 +195,7 @@ module.exports = function(defaults) {
 
 ### Dependency Configuration
 
-You should include Ember Freestyle as a devDependency so that apps using your addon will not include 
+You should include Ember Freestyle as a devDependency so that apps using your addon will not include
 Ember Freestyle CSS and JavaScript in their production payloads.
 
 ### Code Snippets

--- a/README.md
+++ b/README.md
@@ -86,17 +86,18 @@ Optionally divide your style guide sections into subsections using the `freestyl
 
 ```hbs
 {{#freestyle-guide title="My Living Style Guide" subtitle="Showcasing My App's Components"}}
-  {{#freestyle-section name='Visual Style' as |section|}}
-    {{#freestyle-subsection name='Typography' section=section}}
+  {{#freestyle-section name='Visual Style' as |fsg|}}
+    {{#fsg.subsection name='Typography'}}
       {{#freestyle-usage 'visual-style-typography-foo' title='Foo Typography'}}
         {{x-foo-typography}}
       {{/freestyle-usage}}
-    {{/freestyle-subsection}}
-    {{#freestyle-subsection name='Colors' section=section}}
+    {{/fsg.subsection}}
+
+    {{#fsg.subsection name='Colors'}}
       {{#freestyle-usage 'visual-style-colors-fie' title='Fie Colors'}}
         {{x-fie-colors}}
       {{/freestyle-usage}}
-    {{/freestyle-subsection}}
+    {{/fsg.subsection}}
   {{/freestyle-section}}
 {{/freestyle-guide}}
 ```

--- a/addon/templates/components/freestyle-collection.hbs
+++ b/addon/templates/components/freestyle-collection.hbs
@@ -7,7 +7,11 @@
   {{freestyle-variant-list
     variants=variants
     activeKey=activeKey
-    onClickVariant=(action 'setKey')
+    onClickVariant=(action "setKey")
   }}
 {{/if}}
-{{yield this}}
+{{yield
+  (hash
+    variant=(component "freestyle-variant" collection=this)
+  )
+}}

--- a/addon/templates/components/freestyle-section.hbs
+++ b/addon/templates/components/freestyle-section.hbs
@@ -5,6 +5,8 @@
     </div>
   {{/if}}
 {{/if}}
-{{yield (hash
-  subsection=(component 'freestyle-subsection' section=name)
-)}}
+{{yield
+  (hash
+    subsection=(component "freestyle-subsection" section=name)
+  )
+}}

--- a/addon/templates/components/freestyle-section.hbs
+++ b/addon/templates/components/freestyle-section.hbs
@@ -5,4 +5,6 @@
     </div>
   {{/if}}
 {{/if}}
-{{yield name}}
+{{yield (hash
+  subsection=(component 'freestyle-subsection' section=name)
+)}}

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,108 +1,108 @@
 {{#freestyle-guide
-    title='Ember Freestyle'
-    subtitle='Living Style Guide'
-    highlightJsTheme='solarized-light'
+    title="Ember Freestyle"
+    subtitle="Living Style Guide"
+    highlightJsTheme="solarized-light"
 }}
 
-  {{#freestyle-section name='Foo Things' as |section|}}
+  {{#freestyle-section name="Foo Things" as |section|}}
 
-    {{#freestyle-subsection name='Foo Subsection A' section=section}}
-      {{#freestyle-collection title='Foo Collection' defaultKey='normal' inline=true as |collection|}}
+    {{#section.subsection name="Foo Subsection A"}}
+      {{#freestyle-collection title="Foo Collection" defaultKey="normal" inline=true as |collection|}}
 
-        {{#freestyle-variant collection=collection key='normal'}}
-        {{#freestyle-annotation 'foo-normal'}}
-        <h4>A Note About Normal</h4>
-        <p>
-          This comment is coming from a freestyle-annotation component. Use the freestyle-annotation
-          component to write notes in html.
-        </p>
-        {{/freestyle-annotation}}
-          {{#freestyle-note 'foo-normal--notes'}}
-  #### Another Note About Normal
+        {{#collection.variant key="normal"}}
+          {{#freestyle-annotation "foo-normal"}}
+            <h4>A Note About Normal</h4>
+            <p>
+              This comment is coming from a freestyle-annotation component. Use the freestyle-annotation
+              component to write notes in html.
+            </p>
+          {{/freestyle-annotation}}
+          {{#freestyle-note "foo-normal--notes"}}
+            #### Another Note About Normal
 
-  This comment is coming from a `freestyle-note` component. Use the `freestyle-note` component
-  to write notes in markdown.
+            This comment is coming from a `freestyle-note` component. Use the `freestyle-note` component
+            to write notes in markdown.
 
-  ##### Markdown Code Snippet
+            ##### Markdown Code Snippet
 
-  ```javascript
-  // We can include code blocks using markdown
-  function do(something) {
-    console.log(`Doing ${something}`);
-  }
-  ```
+            ```javascript
+            // We can include code blocks using markdown
+            function do(something) {
+              console.log(`Doing ${something}`);
+            }
+            ```
           {{/freestyle-note}}
-          {{#freestyle-usage 'foo-normal' title='Normal' usageTitle='Usage' hbsTitle='Template'}}
-            {{x-foo status='normal'}}
+          {{#freestyle-usage "foo-normal" title="Normal" usageTitle="Usage" hbsTitle="Template"}}
+            {{x-foo status="normal"}}
           {{/freestyle-usage}}
-        {{/freestyle-variant}}
+        {{/collection.variant}}
 
-        {{#freestyle-variant collection=collection key='special'}}
-          {{#freestyle-usage 'foo-special' title='Special'}}
-            {{x-foo status='special'}}
+        {{#collection.variant key="special"}}
+          {{#freestyle-usage "foo-special" title="Special"}}
+            {{x-foo status="special"}}
           {{/freestyle-usage}}
-        {{/freestyle-variant}}
+        {{/collection.variant}}
 
-        {{#freestyle-variant collection=collection key='hyper'}}
-          {{#freestyle-usage 'foo-hyper' title='Hyper'}}
-            {{x-foo status='hyper'}}
+        {{#collection.variant key="hyper"}}
+          {{#freestyle-usage "foo-hyper" title="Hyper"}}
+            {{x-foo status="hyper"}}
           {{/freestyle-usage}}
-        {{/freestyle-variant}}
+        {{/collection.variant}}
 
-        {{#freestyle-variant collection=collection key='classic'}}
-          {{#freestyle-usage 'foo-classic' title='Classic'}}
-            {{x-foo status='classic'}}
+        {{#collection.variant key="classic"}}
+          {{#freestyle-usage "foo-classic" title="Classic"}}
+            {{x-foo status="classic"}}
           {{/freestyle-usage}}
-        {{/freestyle-variant}}
+        {{/collection.variant}}
 
-        {{#freestyle-variant collection=collection key='elegant'}}
-          {{#freestyle-usage 'foo-elegant' title='Elegant'}}
-            {{x-foo status='elegant'}}
+        {{#collection.variant key="elegant"}}
+          {{#freestyle-usage "foo-elegant" title="Elegant"}}
+            {{x-foo status="elegant"}}
           {{/freestyle-usage}}
-        {{/freestyle-variant}}
+        {{/collection.variant}}
 
-        {{#freestyle-variant collection=collection key='tasteful'}}
-          {{#freestyle-usage 'foo-tasteful' title='Tasteful'}}
-            {{x-foo status='tasteful'}}
+        {{#collection.variant key="tasteful"}}
+          {{#freestyle-usage "foo-tasteful" title="Tasteful"}}
+            {{x-foo status="tasteful"}}
           {{/freestyle-usage}}
-        {{/freestyle-variant}}
+        {{/collection.variant}}
 
       {{/freestyle-collection}}
-    {{/freestyle-subsection}}
+    {{/section.subsection}}
 
-    {{#freestyle-subsection name='Foo Subsection B' section=section}}
+    {{#section.subsection name="Foo Subsection B"}}
       {{#freestyle-annotation}}
         This is an annotation in a subsection, mainly to facilitate testing.
       {{/freestyle-annotation}}
-    {{/freestyle-subsection}}
+    {{/section.subsection}}
 
   {{/freestyle-section}}
 
-  {{#freestyle-section name='Visual Style' as |section|}}
+  {{#freestyle-section name="Visual Style" as |section|}}
 
-    {{#freestyle-subsection name='Typography' section=section}}
+    {{#section.subsection name="Typography"}}
 
-      {{#freestyle-usage 'typography-times' title='Times New Roman'}}
-        {{freestyle-typeface fontFamily='Times New Roman'}}
+      {{#freestyle-usage "typography-times" title="Times New Roman"}}
+        {{freestyle-typeface fontFamily="Times New Roman"}}
       {{/freestyle-usage}}
 
-      {{#freestyle-usage 'typography-helvetica' title='Helvetica'}}
-        {{freestyle-typeface fontFamily='Helvetica'}}
+      {{#freestyle-usage "typography-helvetica" title="Helvetica"}}
+        {{freestyle-typeface fontFamily="Helvetica"}}
       {{/freestyle-usage}}
 
-    {{/freestyle-subsection}}
+    {{/section.subsection}}
 
-    {{#freestyle-subsection name='Color' section=section}}
+    {{#section.subsection name="Color"}}
 
-      {{#freestyle-usage 'fp' title='Freestyle Palette'}}
+      {{#freestyle-usage "fp" title="Freestyle Palette"}}
         {{freestyle-palette
             colorPalette=colorPalette
-            title='Dummy App Color Palette'
-            description='This component displays the color palette specified in freestyle/palette.json'
+            title="Dummy App Color Palette"
+            description="This component displays the color palette specified in freestyle/palette.json"
         }}
       {{/freestyle-usage}}
 
-      {{#freestyle-usage 'fpi'
+      {{#freestyle-usage "fpi"
           title="Freestyle Palette Item"
           usageTitle="Template - application.hbs"
           jsTitle="Controller - application.js"
@@ -111,7 +111,7 @@
         {{freestyle-palette-item color=color}}
       {{/freestyle-usage}}
 
-    {{/freestyle-subsection}}
+    {{/section.subsection}}
 
   {{/freestyle-section}}
 


### PR DESCRIPTION
**THIS IS A BREAKING CHANGE.** 

This PR incorporates https://github.com/chrislopresto/ember-freestyle/pull/122 from @dajk and https://github.com/chrislopresto/ember-freestyle/pull/43 from @knownasilya 

- Updates the freestyle-section component to yield contextual freestyle-subsection components
- Updates the freestyle-collection component to yield contextual freestyle-variant components

### Before

```hbs
{{#freestyle-section as |section|}}
  {{#freestyle-subsection section=section}}
    {{#freestyle-collection as |collection|}}
      {{#freestyle-variant colleciton=collection}}
        {{!-- ... --}}
      {{/freestyle-variant}}
    {{/freestyle-collection}}
  {{/freestyle-subsection}}
{{/freestyle-section}}
```

### After

```hbs
{{#freestyle-section as |section|}}
  {{#section.subsection}}
    {{#freestyle-collection as |collection|}}
      {{#collection.variant}}
        {{!-- ... --}}
      {{/collection.variant}}
    {{/freestyle-collection}}
  {{/section.subsection}}
{{/freestyle-section}}
```

Closes #43 
Closes #122 