### PR TITLE
Inherit font-family from component

### DIFF
--- a/addon/styles/components/freestyle-typeface.scss
+++ b/addon/styles/components/freestyle-typeface.scss
@@ -1,11 +1,15 @@
 .FreestyleTypeface {
+  &-previewHero,
+  &-previewSample {
+    font-family: inherit;
+  }
+
   &-previewHero {
     font-size: 140px;
     line-height: 1.05;
   }
 
   &-previewSample {
-    font-family: inherit;
     font-size: 15px;
     margin: 0;
   }

--- a/addon/styles/components/freestyle-typeface.scss
+++ b/addon/styles/components/freestyle-typeface.scss
@@ -5,6 +5,7 @@
   }
 
   &-previewSample {
+    font-family: inherit;
     font-size: 15px;
     margin: 0;
   }


### PR DESCRIPTION
The `freestyle-typeface` component dynamically receives its font-family and writes it as an inline style on the component element. In our case we had a specific font-family defined for all `<p>` tags, so the component's font definition would not trickle down to the `.FreestyleTypeface-previewSample` class.  Thus I have added `font-family: inherit` into that class to allow these `<p>` tags to use the components not and not a globally defined font-family.