### PR TITLE
Improve spacing for hidden subsections

### DIFF
--- a/addon/components/freestyle-subsection.js
+++ b/addon/components/freestyle-subsection.js
@@ -6,7 +6,7 @@ const { computed, inject } = Ember;
 export default Ember.Component.extend({
   layout,
   classNames: ['FreestyleSubsection'],
-
+  classNameBindings: ['show:enabled:disabled'],
   emberFreestyle: inject.service(),
   show: computed('section', 'emberFreestyle.section', 'emberFreestyle.subsection', 'name', function() {
     let focusedSection = this.get('emberFreestyle.section');

--- a/addon/components/freestyle-subsection.js
+++ b/addon/components/freestyle-subsection.js
@@ -6,7 +6,7 @@ const { computed, inject } = Ember;
 export default Ember.Component.extend({
   layout,
   classNames: ['FreestyleSubsection'],
-  classNameBindings: ['show:enabled:disabled'],
+  classNameBindings: ['show:is-showing:is-hidden'],
   emberFreestyle: inject.service(),
   show: computed('section', 'emberFreestyle.section', 'emberFreestyle.subsection', 'name', function() {
     let focusedSection = this.get('emberFreestyle.section');

--- a/addon/styles/components/freestyle-subsection.scss
+++ b/addon/styles/components/freestyle-subsection.scss
@@ -1,4 +1,7 @@
 .FreestyleSubsection {
+  &.disabled {
+    display:none;
+  }
   &-name {
     font-size: 1.3rem;
     margin: 0 1rem;

--- a/addon/styles/components/freestyle-subsection.scss
+++ b/addon/styles/components/freestyle-subsection.scss
@@ -1,7 +1,8 @@
 .FreestyleSubsection {
-  &.disabled {
+  &.is-hidden {
     display:none;
   }
+
   &-name {
     font-size: 1.3rem;
     margin: 0 1rem;

--- a/addon/styles/components/freestyle-typeface.scss
+++ b/addon/styles/components/freestyle-typeface.scss
@@ -1,11 +1,15 @@
 .FreestyleTypeface {
+  &-previewHero,
+  &-previewSample {
+    font-family: inherit;
+  }
+
   &-previewHero {
     font-size: 140px;
     line-height: 1.05;
   }
 
   &-previewSample {
-    font-family: inherit;
     font-size: 15px;
     margin: 0;
   }

--- a/addon/styles/components/freestyle-typeface.scss
+++ b/addon/styles/components/freestyle-typeface.scss
@@ -5,6 +5,7 @@
   }
 
   &-previewSample {
+    font-family: inherit;
     font-size: 15px;
     margin: 0;
   }


### PR DESCRIPTION
Updated Subsection visibility behavior so that subsections no longer take up space in the DOM when they are not visible.

Previously the Subsection content would be hidden, but they would still take up space in the DOM:

<img width="1440" alt="screenshot 2017-07-25 10 12 29" src="https://user-images.githubusercontent.com/736269/28591418-43675b22-714b-11e7-9db7-95ee07123782.png">

With this change the Subsection elements will no longer take up space in the DOM:

<img width="1440" alt="screenshot 2017-07-25 10 19 43" src="https://user-images.githubusercontent.com/736269/28591435-56a0b01c-714b-11e7-9055-37cbb6facbf7.png">
