### PR TITLE
Fixes for freestyleguide header

### DIFF
--- a/addon/styles/components/freestyle-guide.scss
+++ b/addon/styles/components/freestyle-guide.scss
@@ -24,13 +24,13 @@ $FreestyleGuide-boxShadow: 0 2px 5px 0 $FreestyleGuide-shadow1, 0 2px 10px 0 $Fr
   }
 
   &-header {
-    align-items: top;
+    align-items: center;
+    justify-content: space-between;
     border-bottom: solid 1px $FreestyleGuide-color--secondary;
     padding: .5rem 1rem;
   }
 
   &-cta {
-    align-self: center;
     cursor: pointer;
     display: inline-block;
     flex-basis: 20px;
@@ -45,7 +45,6 @@ $FreestyleGuide-boxShadow: 0 2px 5px 0 $FreestyleGuide-shadow1, 0 2px 10px 0 $Fr
   }
 
   &-titleContainer {
-    flex-grow: 1;
     padding: 0 1rem;
     text-align: center;
   }


### PR DESCRIPTION
replaced non-existing `align-items: top;` for `align-items: center;` for the header
which makes it possible to remove `align-self: center;` from the cta

added `justify-content: space-between;` for the header to space the elements correctly
therefore `flex-grow: 1;` can be removed from the title container