### PR TITLE
Add slug as id to freestyle-usage component

### DIFF
--- a/addon/components/freestyle-usage.js
+++ b/addon/components/freestyle-usage.js
@@ -5,9 +5,11 @@ const { computed, inject } = Ember;
 
 let FreestyleUsage = Ember.Component.extend({
   layout,
+  attributeBindings: ['id'],
   classNames: ['FreestyleUsage'],
   classNameBindings: ['inline:FreestyleUsage--inline'],
   emberFreestyle: inject.service(),
+  id: computed.alias('slug'),
   showLabels: computed.alias('emberFreestyle.showLabels'),
   showNotes: computed.alias('emberFreestyle.showNotes'),
   showCode: computed.alias('emberFreestyle.showCode'),


### PR DESCRIPTION
This PR adds the unique slug to the freestyle-usage component's div as an id, making it and its sub-components (title, notes, rendered, usage etc.) addressable by CSS.