### PR TITLE
Update LTS testing config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ env:
     - EMBER_TRY_SCENARIO=ember-lts-2.4
     - EMBER_TRY_SCENARIO=ember-lts-2.8
     - EMBER_TRY_SCENARIO=ember-lts-2.12
+    - EMBER_TRY_SCENARIO=ember-lts-2.16
+    - EMBER_TRY_SCENARIO=ember-lts-2.18
     - EMBER_TRY_SCENARIO=ember-release
     - EMBER_TRY_SCENARIO=ember-beta
     - EMBER_TRY_SCENARIO=ember-canary
@@ -32,6 +34,8 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
+    - env: EMBER_TRY_SCENARIO=ember-lts-2.4
+    - env: EMBER_TRY_SCENARIO=ember-lts-2.8
     - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:
@@ -39,10 +43,10 @@ before_install:
   - export PATH=$HOME/.yarn/bin:$PATH
 
 install:
-  - yarn -v
-  - yarn install --no-lockfile
+  - yarn install --no-lockfile --non-interactive
 
 script:
+  - yarn lint:js
   # Usually, it's ok to finish the test scenario without reverting
   #  to the addon's original dependency state, skipping "cleanup".
   - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO --skip-cleanup

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ dist: trusty
 addons:
   chrome: stable
 
+before_script:
+  - "sudo chown root /opt/google/chrome/chrome-sandbox"
+  - "sudo chmod 4755 /opt/google/chrome/chrome-sandbox"
+
 cache:
   yarn: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,6 @@ install:
   - yarn install --no-lockfile --non-interactive
 
 script:
-  - yarn lint:js
   # Usually, it's ok to finish the test scenario without reverting
   #  to the addon's original dependency state, skipping "cleanup".
   - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO --skip-cleanup

--- a/addon/styles/components/freestyle-dynamic.scss
+++ b/addon/styles/components/freestyle-dynamic.scss
@@ -7,7 +7,7 @@
     }
   }
 
-  &-input-description {
+  &-inputDescription {
     display: block;
   }
 }

--- a/addon/templates/components/freestyle-dynamic-input.hbs
+++ b/addon/templates/components/freestyle-dynamic-input.hbs
@@ -33,7 +33,7 @@
   {{input value=value id=inputId key-up=(action 'sendChangedValue')}}
 {{/if}}
 {{#if description}}
-  <small class="FreestyleDynamic-input-description">
+  <small class="FreestyleDynamic-inputDescription">
     {{description}}
   </small>
 {{/if}}

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -45,6 +45,24 @@ module.exports = {
       }
     },
     {
+      name: 'ember-lts-2.16',
+      npm: {
+        devDependencies: {
+          'ember-native-dom-event-dispatcher': null,
+          'ember-source': '~2.16.0'
+        }
+      }
+    },
+    {
+      name: 'ember-lts-2.18',
+      npm: {
+        devDependencies: {
+          'ember-native-dom-event-dispatcher': null,
+          'ember-source': '~2.18.0'
+        }
+      }
+    },
+    {
       name: 'ember-release',
       bower: {
         dependencies: {


### PR DESCRIPTION
This PR:

- updates Travis config to fix the build: https://github.com/travis-ci/travis-ci/issues/9024
- updates ember-try config to test against the 2.16 and 2.18 LTS Ember releases
- [fixes a CSS selector](https://github.com/suitcss/suit/blob/master/doc/naming-conventions.md)