### PR TITLE
Rename freestyle snippets module

### DIFF
--- a/addon/services/ember-freestyle.js
+++ b/addon/services/ember-freestyle.js
@@ -12,6 +12,7 @@ export default Ember.Service.extend({
   showMenu: true,
 
   defaultTheme: 'zenburn',
+  snippets: computed.alias('freestyle-snippets'),
 
   // must be explicitly set to null here for (query-params s=null ss=null f=null) to work
   section: null,

--- a/app/initializers/ember-freestyle.js
+++ b/app/initializers/ember-freestyle.js
@@ -4,7 +4,7 @@ import ENV from '../config/environment';
 function initialize() {
   const application = arguments[1] || arguments[0];
   let prefix = ENV.modulePrefix;
-  let freestyleModuleRegExp = new RegExp(`^${prefix}\/(snippets)`);
+  let freestyleModuleRegExp = new RegExp(`^${prefix}/(freestyle-snippets)`);
 
   Object.keys(requirejs.entries).filter(function(key) {
     return freestyleModuleRegExp.test(key);

--- a/freestyle-usage-snippet-finder.js
+++ b/freestyle-usage-snippet-finder.js
@@ -118,7 +118,7 @@ SnippetFinder.prototype.write = function (readTree, destDir) {
       var componentSnippets = naiveMerge(freestyleUsageSnippets, freestyleDynamicSnippets, freestyleNoteSnippets);
       var commentSnippets = extractCommentSnippets(fs.readFileSync(filename, 'utf-8'));
       var snippets = naiveMerge(componentSnippets, commentSnippets);
-      for (var name in snippets){
+      for (var name in snippets) {
         fs.writeFileSync(path.join(destDir, name)+path.extname(filename),
                          snippets[name]);
       }

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports = {
     }).concat(snippets));
 
     snippets = flatiron(snippets, {
-      outputFile: 'snippets.js'
+      outputFile: 'freestyle-snippets.js'
     });
     treesToMerge.push(snippets);
 

--- a/tests/dummy/app/templates/documentation.hbs
+++ b/tests/dummy/app/templates/documentation.hbs
@@ -49,7 +49,7 @@
   </p>
 
   <pre><code class="handlebars language-handlebars">
-\{{#freestyle-usage "globally-unique-slug" title="Title To Display In Style Guide"}}
+\{{#freestyle-usage "globally-unique-slug-1 title="Title To Display In Style Guide"}}
   \{{x-foo propa="aaa" propb="bbb"}}
 \{{/freestyle-usage}}
   </code></pre>
@@ -141,10 +141,10 @@
   </p>
 
   <pre><code class="handlebars language-handlebars">
-\{{#freestyle-usage "globally-unique-slug" title="Title To Display In Style Guide"}}
+\{{#freestyle-usage "globally-unique-slug-2" title="Title To Display In Style Guide"}}
   \{{x-foo propa="aaa" propb="bbb"}}
 \{{/freestyle-usage}}
-\{{#freestyle-note "globally-unique-slug--notes"}}
+\{{#freestyle-note "globally-unique-slug-2--notes"}}
   # Contextual Markdown Note for x-foo
 
   You can write helpful _markdown_ notes explaining how the


### PR DESCRIPTION
This PR:

- renames the freestyle snippets module for compatibility with [ember-code-snippet](https://github.com/ef4/ember-code-snippet)
- Renames a documentation snippet slug to avoid a build warning