### PR TITLE
Fix freestyle notes

### DIFF
--- a/freestyle-usage-snippet-finder.js
+++ b/freestyle-usage-snippet-finder.js
@@ -115,7 +115,7 @@ SnippetFinder.prototype.write = function(readTree, destDir) {
       var freestyleUsageSnippets = extractHbsComponentSnippets(fs.readFileSync(filename, 'utf-8'), 'freestyle-usage', self.ui);
       var freestyleDynamicSnippets = extractHbsComponentSnippets(fs.readFileSync(filename, 'utf-8'), 'freestyle-dynamic', self.ui);
       var freestyleNoteSnippets = extractHbsComponentSnippets(fs.readFileSync(filename, 'utf-8'), 'freestyle-note', self.ui);
-      var componentSnippets = naiveMerge(freestyleUsageSnippets, freestyleDynamicSnippets, freestyleNoteSnippets);
+      var componentSnippets = naiveMerge(naiveMerge(freestyleUsageSnippets, freestyleDynamicSnippets), freestyleNoteSnippets);
       var commentSnippets = extractCommentSnippets(fs.readFileSync(filename, 'utf-8'));
       var snippets = naiveMerge(componentSnippets, commentSnippets);
       for (var name in snippets) {

--- a/tests/acceptance/section-rendering-test.js
+++ b/tests/acceptance/section-rendering-test.js
@@ -31,4 +31,15 @@ test('verifying guide subsections', (assert) => {
     assert.equal(sectionVisualStyle.subsections.objectAt(0).text, 'Typography');
     assert.equal(sectionVisualStyle.subsections.objectAt(1).text, 'Color');
   });
+
 });
+
+test('freestyle notes show up', (assert) => {
+  assert.expect(1);
+  andThen(() => {
+    let sectionFooThings = freestyleGuide.content.sections.objectAt(0);
+    let note = sectionFooThings.subsections.objectAt(0).collections.objectAt(0).variants.objectAt(0).noteContent[1];
+
+    assert.ok(note.includes('Another Note About Normal'));
+  })
+})

--- a/tests/pages/freestyle-guide.js
+++ b/tests/pages/freestyle-guide.js
@@ -54,7 +54,8 @@ export default PageObject.create({
           variants: collection('.FreestyleVariant',{
             contains: contains(),
             usageTitle: text('.FreestyleUsage-title'),
-            annotationContains: contains('.FreestyleAnnotation')
+            annotationContains: contains('.FreestyleAnnotation'),
+            noteContent: text('.FreestyleNotes-content', { multiple: true })
           })
         })
       })


### PR DESCRIPTION
Freestyle notes were broken, because I didn't realize `naiveMerge` only takes 2 arguments.

This fixes that, albeit in an ugly way (is there a better merge function we could use?)

Also adds a regression test.