### PR TITLE
chore: Change test command that runs while publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # [0.11.0](https://github.com/chrislopresto/ember-freestyle/compare/v0.10.0...v0.11.0) (2019-10-06)
 
 
+### Features
+
+
+* Update ember-cli-sass to use Dart Sass. [191](https://github.com/chrislopresto/ember-freestyle/pull/191)
 
 # [0.10.0](https://github.com/chrislopresto/ember-freestyle/compare/v0.9.0...v0.10.0) (2018-11-07)
 

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   "scripts": {
     "build": "ember build",
     "lint:js": "eslint ./*.js addon addon-test-support app config lib server test-support tests",
-    "start": "ember serve",
-    "test": "ember try:each",
+    "start": "ember server",
+    "test": "ember test",
     "deploy": "ember github-pages:commit --message \"Deploy gh-pages from commit $(git rev-parse HEAD)\"; git push; git checkout -",
     "release:prepare": "shipjs prepare",
     "release:trigger": "shipjs trigger"


### PR DESCRIPTION
shipjs runs `yarn test` by default before publishing. This PR changes the package.json test script to run `ember test` rather than the unused `ember try` setup that had been there.