### PR TITLE
feat: Support Freestyle Usage|Note angle bracket component invocation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,10 @@ This README provides a lightweight overview of Ember Freestyle to get you going.
 
 To see Ember Freestyle in action, visit [https://chrislopresto.github.io/ember-freestyle/#/acceptance](https://chrislopresto.github.io/ember-freestyle/#/acceptance)
 
-
 ### Compatibility
 
 - Ember.js v3.8 or above
-- Ember CLI v2.13 or above
+- Ember CLI v3.8 or above
 - Node.js v10 or above
 
 ### Support

--- a/freestyle-usage-snippet-finder.js
+++ b/freestyle-usage-snippet-finder.js
@@ -25,7 +25,7 @@ function findFiles(srcDir) {
   });
 }
 
-function extractHbsComponentSnippets(fileContent, componentName, ui) {
+function extractHbsClassicComponentSnippets(fileContent, componentName, ui) {
   let processingSnippet = false;
   let insideOpeningTag = false;
   let snippetLines = [];
@@ -49,10 +49,58 @@ function extractHbsComponentSnippets(fileContent, componentName, ui) {
     } else {
       // Test for start of opening curlies {{#freestyle-usage 'human-readable-name'
       var m = new RegExp('\\{\\{#' + componentName + '\\s+[\'|"](\\S+)[\'|"].*').exec(line);
+
       if (m) {
         processingSnippet = true;
         insideOpeningTag = m[0].indexOf('}}') >= 0; // curlies closed }}
         // Extract snippet positional name param via regex match
+        name = m[1];
+        // TODO: Cleanup freestyle-notes vs freestyle-usage disambiguation here
+        if (name.indexOf('--notes') >= 0) {
+          if (snippets[name]) {
+            ui.writeLine('ember-freestyle detected multiple instances of the freestyle-note slug "' + name +'"');
+          }
+        } else {
+          if (snippets[name + '--usage']) {
+            ui.writeLine('ember-freestyle detected multiple instances of the freestyle-usage slug "' + name +'"');
+          }
+          name += '--usage';
+        }
+      }
+    }
+  });
+  return snippets;
+}
+
+function extractHbsAngleBracketComponentSnippets(fileContent, componentName, ui) {
+  let processingSnippet = false;
+  let insideOpeningTag = false;
+  let snippetLines = [];
+  let snippets = {};
+  let name;
+  fileContent.split("\n").forEach(function(line) {
+    if (processingSnippet) {
+      if (insideOpeningTag) {
+        // Test for start of closing angles </FreestyleUsage
+        if (new RegExp('\\<\\/' + componentName).test(line)) {
+          processingSnippet = false;
+          insideOpeningTag = false;
+          snippets[name] = snippetLines.join("\n");
+          snippetLines = [];
+        } else {
+          snippetLines.push(line);
+        }
+      } else {
+        insideOpeningTag = line.indexOf('>') >= 0; // angles closed >
+      }
+    } else {
+      // Test for start of opening angles <FreestyleUsage @slug='human-readable-name'
+      var m = new RegExp('\\<' + componentName + '\\s+.*@slug=[\'"](\\S+)[\'"].*').exec(line);
+
+      if (m) {
+        processingSnippet = true;
+        insideOpeningTag = m[0].indexOf('>') >= 0; // angles closed >
+        // Extract snippet slug name param via regex match
         name = m[1];
         // TODO: Cleanup freestyle-notes vs freestyle-usage disambiguation here
         if (name.indexOf('--notes') >= 0) {
@@ -106,10 +154,16 @@ module.exports = class SnippetFinder extends BroccoliPlugin {
   build() {
     return findFiles(this.inputPaths[0]).then((files) => {
       files.forEach((filename) => {
-        let freestyleUsageSnippets = extractHbsComponentSnippets(fs.readFileSync(filename, 'utf-8'), 'freestyle-usage', this.ui);
-        let freestyleDynamicSnippets = extractHbsComponentSnippets(fs.readFileSync(filename, 'utf-8'), 'freestyle-dynamic', this.ui);
-        let freestyleNoteSnippets = extractHbsComponentSnippets(fs.readFileSync(filename, 'utf-8'), 'freestyle-note', this.ui);
-        let componentSnippets = naiveMerge(naiveMerge(freestyleUsageSnippets, freestyleDynamicSnippets), freestyleNoteSnippets);
+        let freestyleUsageSnippets = extractHbsClassicComponentSnippets(fs.readFileSync(filename, 'utf-8'), 'freestyle-usage', this.ui);
+        let freestyleDynamicSnippets = extractHbsClassicComponentSnippets(fs.readFileSync(filename, 'utf-8'), 'freestyle-dynamic', this.ui);
+        let freestyleNoteSnippets = extractHbsClassicComponentSnippets(fs.readFileSync(filename, 'utf-8'), 'freestyle-note', this.ui);
+        // add glimmer/octane angle-bracket notation support
+        let glimmerUsageSnippets = extractHbsAngleBracketComponentSnippets(fs.readFileSync(filename, 'utf-8'), 'FreestyleUsage', this.ui);
+        let glimmerDynamicSnippets = extractHbsAngleBracketComponentSnippets(fs.readFileSync(filename, 'utf-8'), 'FreestyleDynamic', this.ui);
+        let glimmerNoteSnippets = extractHbsAngleBracketComponentSnippets(fs.readFileSync(filename, 'utf-8'), 'FreestyleNote', this.ui);
+
+        let componentSnippets = naiveMerge(naiveMerge(naiveMerge(naiveMerge(naiveMerge(freestyleUsageSnippets, freestyleDynamicSnippets), freestyleNoteSnippets), glimmerUsageSnippets), glimmerDynamicSnippets), glimmerNoteSnippets);
+
         let commentSnippets = extractCommentSnippets(fs.readFileSync(filename, 'utf-8'));
         let snippets = naiveMerge(componentSnippets, commentSnippets);
         for (var name in snippets) {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "postrelease": "./script/postrelease"
   },
   "dependencies": {
-    "babel-eslint": "^10.0.3",
     "broccoli-flatiron": "0.1.3",
     "broccoli-merge-trees": "^3.0.1",
     "ember-cli-babel": "^7.13.0",
@@ -37,6 +36,7 @@
   "devDependencies": {
     "@ember/optional-features": "^1.3.0",
     "@glimmer/component": "^1.0.0",
+    "babel-eslint": "^10.0.3",
     "broccoli-asset-rev": "^3.0.0",
     "ember-auto-import": "^1.5.3",
     "ember-cli": "~3.15.2",

--- a/tests/dummy/app/templates/acceptance.hbs
+++ b/tests/dummy/app/templates/acceptance.hbs
@@ -115,34 +115,34 @@
 
     {{#section.subsection name="Typography"}}
 
-      {{#freestyle-usage "typography-times" title="Times New Roman"}}
-        {{freestyle-typeface fontFamily="Times New Roman"}}
-      {{/freestyle-usage}}
+      <FreestyleUsage @slug="typography-times" @title="Times New Roman">
+        <FreestyleTypeface @fontFamily="Times New Roman" />
+      </FreestyleUsage>
 
-      {{#freestyle-usage "typography-helvetica" title="Helvetica"}}
-        {{freestyle-typeface fontFamily="Helvetica"}}
-      {{/freestyle-usage}}
+      <FreestyleUsage @slug="typography-helvetica" @title="Helvetica">
+        <FreestyleTypeface @fontFamily="Helvetica" />
+      </FreestyleUsage>
 
     {{/section.subsection}}
 
     {{#section.subsection name="Color"}}
 
-      {{#freestyle-usage "fp" title="Freestyle Palette"}}
-        {{freestyle-palette
-            colorPalette=colorPalette
-            title="Dummy App Color Palette"
-            description="This component displays the color palette specified in freestyle/palette.json"
-        }}
-      {{/freestyle-usage}}
+      <FreestyleUsage @slug="fp" @title="Freestyle Palette">
+        <FreestylePalette
+          @colorPalette={{this.colorPalette}}
+          @title="Dummy App Color Palette"
+          @description="This component displays the color palette specified in freestyle/palette.json"
+        />
+      </FreestyleUsage>
 
-      {{#freestyle-usage "fpi"
-          title="Freestyle Palette Item"
-          usageTitle="Template - application.hbs"
-          jsTitle="Controller - application.js"
-          scssTitle="SCSS - freestyle-palette-item.scss"
-      }}
-        {{freestyle-palette-item color=color}}
-      {{/freestyle-usage}}
+      <FreestyleUsage @slug="fpi"
+        @title="Freestyle Palette Item"
+        @usageTitle="Template - application.hbs"
+        @jsTitle="Controller - application.js"
+        @scssTitle="SCSS - freestyle-palette-item.scss"
+      >
+        <FreestylePaletteItem @color={{this.color}} />
+      </FreestyleUsage>
 
     {{/section.subsection}}
 

--- a/tests/integration/components/freestyle-usage/component-test.js
+++ b/tests/integration/components/freestyle-usage/component-test.js
@@ -242,4 +242,17 @@ module('Integration | Component | freestyle usage', function(hooks) {
     assert.equal(usage.numCodeSection, 0);
     assert.equal(usage.numNotesSection, 0);
   });
+
+  test('it renders the passed in block for angle bracket components', async function(assert) {
+    assert.expect(1);
+
+    await render(hbs`
+      <FreestyleUsage @slug="componentA">
+        hello from component A
+      </FreestyleUsage>
+      `);
+
+    assert.equal(usage.content, 'hello from component A');
+  });
+
 });


### PR DESCRIPTION
fix for issue #188 

kept support for curly-brackets

attempted to clean up the `componentSnippets` build by iterating through an array of `componentName` values, but the resulting code was taking longer to clean up than just adding and merging three more snippets

willing to work to clean up and DRY out the code with some guidance, just wanted to get it out there because we currently have a need for it with our ember-octane project

thanks in advance! and thanks for making this addon in the first place, it's rad