### PR TITLE
fix(accessibility): ensure freestyle-snippet content is accessible by screenreader

### DIFF
--- a/addon/templates/components/freestyle-snippet.hbs
+++ b/addon/templates/components/freestyle-snippet.hbs
@@ -4,5 +4,5 @@
   </div>
 {{/if}}
 {{#if source}}
-<pre class={{language}}>{{source}}</pre>
+<pre class={{language}} tabindex="0">{{source}}</pre>
 {{/if}}


### PR DESCRIPTION
When running the default generated freestyle-guide through aXe (an accessibility auditing tool used by many web tools like Chrome and ember-a11y-testing), we found that the keyboard could not focus on the scrollable region of the tool. Adding `tabindex="0"` here allows the keyboard user to focus the snippet and scroll the region.

https://dequeuniversity.com/rules/axe/3.3/scrollable-region-focusable