### PR TITLE
feat: Add option to not show all in menu

### DIFF
--- a/addon/components/freestyle-guide/index.hbs
+++ b/addon/components/freestyle-guide/index.hbs
@@ -25,10 +25,17 @@
   <main class="FreestyleGuide-body">
     <article class="FreestyleGuide-content">
       {{yield}}
+      {{#if (and (not this.allowRenderingAllSections) (not this.isSectionSelected))}}
+        <div class="FreestyleGuide-chooseSectionMessage" data-test-choose-section>
+          <span>Choose a section from the menu</span>
+        </div>
+      {{/if}}
     </article>
     {{#if this.showMenu}}
       <nav class="FreestyleGuide-nav">
-        <FreestyleMenu />
+        <FreestyleMenu
+          @includeAllOption={{this.allowRenderingAllSections}}
+        />
       </nav>
     {{/if}}
     {{#if this.showAside}}

--- a/addon/components/freestyle-guide/index.js
+++ b/addon/components/freestyle-guide/index.js
@@ -3,7 +3,7 @@ import { reads } from 'macro-decorators';
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-
+import { isBlank } from '@ember/utils';
 export default class FreestyleGuide extends Component {
   @service emberFreestyle;
 
@@ -19,6 +19,12 @@ export default class FreestyleGuide extends Component {
   }
   set highlightJsTheme(val) {
     this.emberFreestyle.set('defaultTheme', val);
+  }
+  @reads('emberFreestyle.allowRenderingAllSections', true)
+  allowRenderingAllSections;
+
+  get isSectionSelected() {
+    return !isBlank(this.emberFreestyle.section);
   }
 
   @reads('emberFreestyle.showMenu') showMenu;

--- a/addon/components/freestyle-menu/index.hbs
+++ b/addon/components/freestyle-menu/index.hbs
@@ -1,9 +1,11 @@
 <ul class="FreestyleMenu">
-  <li class="FreestyleMenu-item">
-    <LinkTo @query={{hash s=null ss=null f=null}} class="FreestyleMenu-itemLink">
-      All
-    </LinkTo>
-  </li>
+  {{#if this.menuIncludesAllItem}}
+    <li class="FreestyleMenu-item">
+      <LinkTo @query={{hash s=null ss=null f=null}} class="FreestyleMenu-itemLink">
+        All
+      </LinkTo>
+    </li>
+  {{/if}}
   {{#each this.menu as |section|}}
     <li class="FreestyleMenu-item">
       <LinkTo @query={{hash f=null s=section.name ss=null}} class="FreestyleMenu-itemLink">

--- a/addon/components/freestyle-menu/index.hbs
+++ b/addon/components/freestyle-menu/index.hbs
@@ -1,5 +1,5 @@
 <ul class="FreestyleMenu">
-  {{#if this.menuIncludesAllItem}}
+  {{#if this.includeAllOption}}
     <li class="FreestyleMenu-item">
       <LinkTo @query={{hash s=null ss=null f=null}} class="FreestyleMenu-itemLink">
         All

--- a/addon/components/freestyle-menu/index.js
+++ b/addon/components/freestyle-menu/index.js
@@ -6,5 +6,6 @@ export default Component.extend({
   tagName: '',
 
   emberFreestyle: service(),
-  menu: readOnly('emberFreestyle.menu'),
+  menuIncludesAllItem: readOnly('emberFreestyle.menuIncludesAllItem'),
+  menu: readOnly('emberFreestyle.menu')
 });

--- a/addon/components/freestyle-menu/index.js
+++ b/addon/components/freestyle-menu/index.js
@@ -1,11 +1,9 @@
 import { inject as service } from '@ember/service';
-import { readOnly } from '@ember/object/computed';
-import Component from '@ember/component';
+import { reads } from 'macro-decorators';
+import Component from '@glimmer/component';
 
-export default Component.extend({
-  tagName: '',
-
-  emberFreestyle: service(),
-  includeAllOption: true,
-  menu: readOnly('emberFreestyle.menu'),
-});
+export default class FreestyleMenu extends Component {
+  @service emberFreestyle;
+  @reads('args.includeAllOption', true) includeAllOption;
+  @reads('emberFreestyle.menu') menu;
+}

--- a/addon/components/freestyle-menu/index.js
+++ b/addon/components/freestyle-menu/index.js
@@ -6,6 +6,6 @@ export default Component.extend({
   tagName: '',
 
   emberFreestyle: service(),
-  menuIncludesAllItem: readOnly('emberFreestyle.menuIncludesAllItem'),
+  includeAllOption: true,
   menu: readOnly('emberFreestyle.menu'),
 });

--- a/addon/components/freestyle-menu/index.js
+++ b/addon/components/freestyle-menu/index.js
@@ -7,5 +7,5 @@ export default Component.extend({
 
   emberFreestyle: service(),
   menuIncludesAllItem: readOnly('emberFreestyle.menuIncludesAllItem'),
-  menu: readOnly('emberFreestyle.menu')
+  menu: readOnly('emberFreestyle.menu'),
 });

--- a/addon/components/freestyle-section/index.hbs
+++ b/addon/components/freestyle-section/index.hbs
@@ -1,9 +1,10 @@
 <div
   class="FreestyleSection {{if this.show 'FreestyleSection--showing' 'FreestyleSection--hidden'}}"
+    {{did-insert (fn this.emberFreestyle.registerSection @name null)}}
   ...attributes
 >
   {{#if this.show}}
-    {{#if this.hasName}}
+    {{#if @name}}
       <div class="FreestyleSection-name">
         {{@name}}
       </div>

--- a/addon/components/freestyle-section/index.js
+++ b/addon/components/freestyle-section/index.js
@@ -2,18 +2,15 @@
 
 import { inject as service } from '@ember/service';
 import { and } from '@ember/object/computed';
-import { isBlank } from '@ember/utils';
 import Component from '@ember/component';
-import { computed } from '@ember/object';
 
 export default Component.extend({
   tagName: '',
 
   emberFreestyle: service(),
-  show: computed('emberFreestyle.section', 'name', function () {
-    let focusedSection = this.emberFreestyle.section;
-    return isBlank(focusedSection) || this.name === focusedSection;
-  }),
+  get show() {
+    return this.emberFreestyle.shouldShowSection(this.name);
+  },
 
   showName: and('emberFreestyle.notFocused', 'name'),
   hasName: and('showName', 'name'),

--- a/addon/components/freestyle-section/index.js
+++ b/addon/components/freestyle-section/index.js
@@ -1,22 +1,11 @@
 /* eslint-disable ember/no-component-lifecycle-hooks */
 
 import { inject as service } from '@ember/service';
-import { and } from '@ember/object/computed';
-import Component from '@ember/component';
+import Component from '@glimmer/component';
 
-export default Component.extend({
-  tagName: '',
-
-  emberFreestyle: service(),
+export default class FreestyleSection extends Component {
+  @service emberFreestyle;
   get show() {
-    return this.emberFreestyle.shouldShowSection(this.name);
-  },
-
-  showName: and('emberFreestyle.notFocused', 'name'),
-  hasName: and('showName', 'name'),
-
-  willRender() {
-    this._super(...arguments);
-    this.emberFreestyle.registerSection(this.name);
-  },
-});
+    return this.emberFreestyle.shouldShowSection(this.args.name);
+  }
+}

--- a/addon/components/freestyle-subsection/index.hbs
+++ b/addon/components/freestyle-subsection/index.hbs
@@ -1,6 +1,9 @@
-<div class="FreestyleSubsection {{if this.show 'is-showing' 'is-hidden'}}">
+<div class="FreestyleSubsection {{if this.show 'is-showing' 'is-hidden'}}"
+  {{did-insert (fn this.emberFreestyle.registerSection @section @name)}}
+  ...attributes
+>
   {{#if this.show}}
-    {{#if this.hasName}}
+    {{#if @name}}
       <div class="FreestyleSubsection-name">
         {{@name}}
       </div>

--- a/addon/components/freestyle-subsection/index.js
+++ b/addon/components/freestyle-subsection/index.js
@@ -1,25 +1,13 @@
 /* eslint-disable ember/no-component-lifecycle-hooks */
 import { inject as service } from '@ember/service';
-import { and } from '@ember/object/computed';
-import Component from '@ember/component';
-import { computed } from '@ember/object';
+import Component from '@glimmer/component';
 
-export default Component.extend({
-  tagName: '',
-  emberFreestyle: service(),
-  show: computed(
-    'section',
-    'emberFreestyle.{allowRenderingAllSections,section,subsection}',
-    'name',
-    function () {
-      return this.emberFreestyle.shouldShowSubsection(this.section, this.name);
-    }
-  ),
-
-  showName: and('emberFreestyle.notFocused', 'name'),
-  hasName: and('showName', 'name'),
-  willRender() {
-    this._super(...arguments);
-    this.emberFreestyle.registerSection(this.section, this.name);
-  },
-});
+export default class FreestyleSubsection extends Component {
+  @service emberFreestyle;
+  get show() {
+    return this.emberFreestyle.shouldShowSubsection(
+      this.args.section,
+      this.args.name
+    );
+  }
+}

--- a/addon/components/freestyle-subsection/index.js
+++ b/addon/components/freestyle-subsection/index.js
@@ -1,7 +1,6 @@
 /* eslint-disable ember/no-component-lifecycle-hooks */
 import { inject as service } from '@ember/service';
 import { and } from '@ember/object/computed';
-import { isBlank } from '@ember/utils';
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 
@@ -10,19 +9,10 @@ export default Component.extend({
   emberFreestyle: service(),
   show: computed(
     'section',
-    'emberFreestyle.{section,subsection}',
+    'emberFreestyle.{allowRenderingAllSections,section,subsection}',
     'name',
     function () {
-      let focusedSection = this.emberFreestyle.section;
-      let showSection =
-        isBlank(focusedSection) || this.section === focusedSection;
-
-      if (!showSection) {
-        return false;
-      }
-
-      let focusedSubsection = this.emberFreestyle.subsection;
-      return isBlank(focusedSubsection) || this.name === focusedSubsection;
+      return this.emberFreestyle.shouldShowSubsection(this.section, this.name);
     }
   ),
 

--- a/addon/services/ember-freestyle.js
+++ b/addon/services/ember-freestyle.js
@@ -4,6 +4,8 @@ import { isPresent } from '@ember/utils';
 import { A } from '@ember/array';
 import { Promise } from 'rsvp';
 import { tracked } from '@glimmer/tracking';
+import { isBlank } from '@ember/utils';
+
 export default class EmberFreestyleService extends Service {
   @tracked showLabels = true;
   @tracked showNotes = true;
@@ -12,7 +14,7 @@ export default class EmberFreestyleService extends Service {
 
   @tracked menu = null;
   @tracked showMenu = true;
-  @tracked menuIncludesAllItem = true;
+  @tracked allowRenderingAllSections = true;
 
   defaultTheme = 'zenburn';
 
@@ -23,6 +25,22 @@ export default class EmberFreestyleService extends Service {
 
   get notFocused() {
     return !this.focus;
+  }
+
+  shouldShowSection(sectionName) {
+    let focusedSection = this.section;
+    if (isBlank(focusedSection) && this.allowRenderingAllSections) {
+      return true;
+    }
+    return sectionName === focusedSection;
+  }
+
+  shouldShowSubsection(sectionName, subsectionName) {
+    if (!this.shouldShowSection(sectionName)) {
+      return false;
+    }
+    let focusedSubsection = this.subsection;
+    return isBlank(focusedSubsection) || subsectionName === focusedSubsection;
   }
 
   hljsVersion = '9.12.0';

--- a/addon/services/ember-freestyle.js
+++ b/addon/services/ember-freestyle.js
@@ -12,6 +12,7 @@ export default class EmberFreestyleService extends Service {
 
   @tracked menu = null;
   @tracked showMenu = true;
+  @tracked menuIncludesAllItem = true;
 
   defaultTheme = 'zenburn';
 

--- a/addon/services/ember-freestyle.js
+++ b/addon/services/ember-freestyle.js
@@ -5,7 +5,7 @@ import { A } from '@ember/array';
 import { Promise } from 'rsvp';
 import { tracked } from '@glimmer/tracking';
 import { isBlank } from '@ember/utils';
-
+import { action } from '@ember/object';
 export default class EmberFreestyleService extends Service {
   @tracked showLabels = true;
   @tracked showNotes = true;
@@ -113,6 +113,7 @@ export default class EmberFreestyleService extends Service {
 
   // menu - tree structure of named sections with named subsections
 
+  @action
   registerSection(sectionName, subsectionName = '') {
     let menu = this.menu || A([]);
     if (!menu.filterBy('name', sectionName).length) {

--- a/addon/styles/components/freestyle-guide.scss
+++ b/addon/styles/components/freestyle-guide.scss
@@ -107,4 +107,13 @@ $FreestyleGuide-boxShadow: 0 2px 5px 0 $FreestyleGuide-shadow1, 0 2px 10px 0 $Fr
       order: 1;
     }
   }
+
+  &-chooseSectionMessage {
+    display: flex;
+    height: 100%;
+    font-size: 1.4rem;
+    & > span {
+      margin: auto;
+    }
+  }
 }

--- a/tests/acceptance/collection-navigation-test.js
+++ b/tests/acceptance/collection-navigation-test.js
@@ -22,9 +22,9 @@ module('Acceptance | collection navigation', function (hooks) {
   test('verifying variantListItem selection', async (assert) => {
     assert.expect(36);
 
-    let fooCollection = freestyleGuide.content.sections
+    let fooCollection = freestyleGuide.content.visibleSections
       .objectAt(2)
-      .subsections.objectAt(0)
+      .visibleSubsections.objectAt(0)
       .collections.objectAt(0);
 
     for (let idx = 0; idx < variantKeys.length; idx++) {

--- a/tests/acceptance/collection-rendering-test.js
+++ b/tests/acceptance/collection-rendering-test.js
@@ -11,13 +11,13 @@ module('Acceptance | collection rendering', function (hooks) {
   });
 
   test('verifying freestyle collection', (assert) => {
-    let sectionFooThings = freestyleGuide.content.sections.objectAt(2);
+    let sectionFooThings = freestyleGuide.content.visibleSections.objectAt(2);
     assert.equal(
-      sectionFooThings.subsections.objectAt(0).collections.length,
+      sectionFooThings.visibleSubsections.objectAt(0).collections.length,
       1
     );
 
-    let fooCollection = sectionFooThings.subsections
+    let fooCollection = sectionFooThings.visibleSubsections
       .objectAt(0)
       .collections.objectAt(0);
     assert.equal(fooCollection.title, 'Foo Collection');

--- a/tests/acceptance/section-navigation-test.js
+++ b/tests/acceptance/section-navigation-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import freestyleGuide from '../pages/freestyle-guide';
+import { pauseTest } from '@ember/test-helpers';
 
 module('Acceptance | section navigation', function (hooks) {
   setupApplicationTest(hooks);
@@ -15,8 +16,9 @@ module('Acceptance | section navigation', function (hooks) {
     assert.equal(freestyleGuide.header.subtitle, 'Living Style Guide');
   });
 
-  test('verifying menu sections', (assert) => {
+  test('verifying menu sections', async (assert) => {
     assert.expect(6);
+    await pauseTest();
     assert.equal(freestyleGuide.menu.sections.length, 6);
     assert.equal(freestyleGuide.menu.sections.objectAt(0).text, 'All');
     assert.equal(freestyleGuide.menu.sections.objectAt(1).text, 'Albums');

--- a/tests/acceptance/section-navigation-test.js
+++ b/tests/acceptance/section-navigation-test.js
@@ -1,7 +1,6 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import freestyleGuide from '../pages/freestyle-guide';
-import { pauseTest } from '@ember/test-helpers';
 
 module('Acceptance | section navigation', function (hooks) {
   setupApplicationTest(hooks);
@@ -18,7 +17,7 @@ module('Acceptance | section navigation', function (hooks) {
 
   test('verifying menu sections', async (assert) => {
     assert.expect(6);
-    await pauseTest();
+
     assert.equal(freestyleGuide.menu.sections.length, 6);
     assert.equal(freestyleGuide.menu.sections.objectAt(0).text, 'All');
     assert.equal(freestyleGuide.menu.sections.objectAt(1).text, 'Albums');

--- a/tests/acceptance/section-navigation-test.js
+++ b/tests/acceptance/section-navigation-test.js
@@ -47,4 +47,26 @@ module('Acceptance | section navigation', function (hooks) {
     assert.equal(sectionVisualStyle.subsections.objectAt(0).text, 'Typography');
     assert.equal(sectionVisualStyle.subsections.objectAt(1).text, 'Color');
   });
+
+  module('with allowRenderingAllSections set to false', function (hooks) {
+    hooks.beforeEach(async function () {
+      let service = this.owner.lookup('service:ember-freestyle');
+      service.allowRenderingAllSections = false;
+    });
+    test('verifying menu sections', async (assert) => {
+      assert.expect(5);
+
+      assert.equal(freestyleGuide.menu.sections.length, 5);
+      assert.equal(freestyleGuide.menu.sections.objectAt(0).text, 'Albums');
+      assert.equal(freestyleGuide.menu.sections.objectAt(2).text, 'Foo Things');
+      assert.equal(
+        freestyleGuide.menu.sections.objectAt(3).text,
+        'Dynamic Properties'
+      );
+      assert.equal(
+        freestyleGuide.menu.sections.objectAt(4).text,
+        'Visual Style'
+      );
+    });
+  });
 });

--- a/tests/acceptance/section-rendering-test.js
+++ b/tests/acceptance/section-rendering-test.js
@@ -10,52 +10,83 @@ module('Acceptance | section rendering', function (hooks) {
   });
 
   test('verifying guide sections', (assert) => {
-    assert.expect(5);
-    assert.equal(freestyleGuide.content.sections.length, 5);
-    assert.equal(freestyleGuide.content.sections.objectAt(0).text, 'Albums');
+    assert.expect(6);
+    assert.equal(freestyleGuide.content.visibleSections.length, 5);
     assert.equal(
-      freestyleGuide.content.sections.objectAt(2).text,
+      freestyleGuide.content.visibleSections.objectAt(0).text,
+      'Albums'
+    );
+    assert.equal(
+      freestyleGuide.content.visibleSections.objectAt(2).text,
       'Foo Things'
     );
     assert.equal(
-      freestyleGuide.content.sections.objectAt(3).text,
+      freestyleGuide.content.visibleSections.objectAt(3).text,
       'Dynamic Properties'
     );
     assert.equal(
-      freestyleGuide.content.sections.objectAt(4).text,
+      freestyleGuide.content.visibleSections.objectAt(4).text,
       'Visual Style'
     );
+    assert.dom('[data-test-choose-section]').doesNotExist();
   });
 
   test('verifying guide subsections', (assert) => {
     assert.expect(6);
-    let sectionFooThings = freestyleGuide.content.sections.objectAt(2);
-    assert.equal(sectionFooThings.subsections.length, 2);
+    let sectionFooThings = freestyleGuide.content.visibleSections.objectAt(2);
+    assert.equal(sectionFooThings.visibleSubsections.length, 2);
     assert.equal(
-      sectionFooThings.subsections.objectAt(0).text,
+      sectionFooThings.visibleSubsections.objectAt(0).text,
       'Foo Subsection A'
     );
     assert.equal(
-      sectionFooThings.subsections.objectAt(1).text,
+      sectionFooThings.visibleSubsections.objectAt(1).text,
       'Foo Subsection B'
     );
 
-    let sectionVisualStyle = freestyleGuide.content.sections.objectAt(4);
-    assert.equal(sectionVisualStyle.subsections.length, 2);
-    assert.equal(sectionVisualStyle.subsections.objectAt(0).text, 'Typography');
-    assert.equal(sectionVisualStyle.subsections.objectAt(1).text, 'Color');
+    let sectionVisualStyle = freestyleGuide.content.visibleSections.objectAt(4);
+    assert.equal(sectionVisualStyle.visibleSubsections.length, 2);
+    assert.equal(
+      sectionVisualStyle.visibleSubsections.objectAt(0).text,
+      'Typography'
+    );
+    assert.equal(
+      sectionVisualStyle.visibleSubsections.objectAt(1).text,
+      'Color'
+    );
   });
 
   test('freestyle annotations show up', (assert) => {
     assert.expect(1);
-    let sectionFooThings = freestyleGuide.content.sections.objectAt(2);
+    let sectionFooThings = freestyleGuide.content.visibleSections.objectAt(2);
     assert.ok(
-      sectionFooThings.subsections
+      sectionFooThings.visibleSubsections
         .objectAt(0)
         .collections.objectAt(0)
         .variants.objectAt(0)
         .annotationContains('A Note About Normal'),
       'Normal annotation renders'
     );
+  });
+
+  module('with allowRenderingAllSections set to false', function (hooks) {
+    hooks.beforeEach(async function () {
+      let service = this.owner.lookup('service:ember-freestyle');
+      service.allowRenderingAllSections = false;
+    });
+    test('verifying guide sections', async (assert) => {
+      assert.expect(3);
+      assert.equal(
+        freestyleGuide.content.visibleSections.length,
+        0,
+        'Sections should be hidden'
+      );
+      assert.equal(
+        freestyleGuide.content.allVisibleSubsections.length,
+        0,
+        'Subsections should be hidden'
+      );
+      assert.dom('[data-test-choose-section]').exists();
+    });
   });
 });

--- a/tests/dummy/app/templates/documentation.hbs
+++ b/tests/dummy/app/templates/documentation.hbs
@@ -237,6 +237,29 @@
       {{/let}}
     </p>
 
+    <h2>Showing/Hiding the "All" components view</h2>
+
+    <p>
+      You might find that rendering all your freestyle components in one page isn't desirable. The page might run slow,
+      or you might want to encourage developers to use sub-sections. To hide the all menu option, and
+      set the ember-freestyle service's `allowRenderingAllSections` to false. 
+    </p>
+
+    <b><p>app/routes/application.js</p></b>
+
+    <pre><code class="javascript language-javascript">
+  import Route from '@ember/routing/route';
+  import { inject as service } from '@ember/service';
+
+  export default class ApplicationRoute extends Route {
+    @service emberFreestyle;
+
+    beforeModel() {
+      this.emberFreestyle.allowRenderingAllSections = false;
+    }
+  }
+    </code></pre>
+
     <h2>Removing Ember Freestyle from Your Production Payload</h2>
 
     <p>
@@ -256,24 +279,6 @@
     };
   }
     </code></pre>
-
-    <h2>Showing/Hiding the "All" component view</h2>
-
-    <p>
-      You might find that rendering all your freestyle components in one page isn't desirable. The page might run slow,
-      or you might want to encourage developers to use sub-sections. To hide the all menu option, override the menuIncludesAllItem to be false. 
-    </p>
-
-    <b><p>app/services/ember-freestyle.js</p></b>
-
-    <pre><code class="javascript language-javascript">
-    import BaseService from 'ember-freestyle/services/ember-freestyle';
-
-    export default BaseService.extend({
-      menuIncludesAllItem: false,
-    });
-    </code></pre>
-
 
 
     <h2>Living Style Guide Driven Development</h2>

--- a/tests/dummy/app/templates/documentation.hbs
+++ b/tests/dummy/app/templates/documentation.hbs
@@ -257,6 +257,25 @@
   }
     </code></pre>
 
+    <h2>Showing/Hiding the "All" component view</h2>
+
+    <p>
+      You might find that rendering all your freestyle components in one page isn't desirable. The page might run slow,
+      or you might want to encourage developers to use sub-sections. To not show the all menu option, override the menuIncludesAllItem to be false. 
+    </p>
+
+    <b><p>app/services/ember-freestyle.js</p></b>
+
+    <pre><code class="javascript language-javascript">
+    import BaseService from 'ember-freestyle/services/ember-freestyle';
+
+    export default BaseService.extend({
+      menuIncludesAllItem: false,
+    });
+    </code></pre>
+
+
+
     <h2>Living Style Guide Driven Development</h2>
 
     <p>

--- a/tests/dummy/app/templates/documentation.hbs
+++ b/tests/dummy/app/templates/documentation.hbs
@@ -261,7 +261,7 @@
 
     <p>
       You might find that rendering all your freestyle components in one page isn't desirable. The page might run slow,
-      or you might want to encourage developers to use sub-sections. To not show the all menu option, override the menuIncludesAllItem to be false. 
+      or you might want to encourage developers to use sub-sections. To hide the all menu option, override the menuIncludesAllItem to be false. 
     </p>
 
     <b><p>app/services/ember-freestyle.js</p></b>

--- a/tests/pages/freestyle-guide.js
+++ b/tests/pages/freestyle-guide.js
@@ -33,10 +33,9 @@ export default PageObject.create({
   content: {
     scope: '.FreestyleGuide-content',
 
-    sections: collection('.FreestyleSection', {
+    visibleSections: collection('.FreestyleSection--showing', {
       text: text('.FreestyleSection-name'),
-
-      subsections: collection('.FreestyleSubsection', {
+      visibleSubsections: collection('.FreestyleSubsection.is-showing', {
         text: text('.FreestyleSubsection-name'),
         collections: collection('.FreestyleCollection', {
           title: text('.FreestyleCollection-title'),
@@ -59,5 +58,6 @@ export default PageObject.create({
         }),
       }),
     }),
+    allVisibleSubsections: collection('.FreestyleSubsection.is-showing', {}),
   },
 });


### PR DESCRIPTION
My team has found that the all components menu isn't very performant since we have a ton of components, so we wanted a way to hide it from the user altogether. 

This PR adds flag to the freestyle service that the user can tap into and hide the `all` components menu in side nav. 