### PR TITLE
bug: Don't run AST transform on freestyle itself, just on it's parent app/addon

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,9 @@ module.exports = {
   },
 
   setupPreprocessorRegistry(type, registry) {
+    if (type !== 'parent') {
+      return;
+    }
     let pluginObj = this._buildPlugin();
     pluginObj.parallelBabel = {
       requireFile: __filename,


### PR DESCRIPTION
This avoids a bug where the rewriting causes an error when run in ember-beta or newer with embroider:

```
The `yield` keyword was used incorrectly. It was used as a call expression, but its valid usages are:

- As an append statement, as in: {{yield}}

Error caused by:

|
|  {{yield this.dynamicPropertyValues}}
|

(error occurred in 'ember-freestyle/components/freestyle-dynamic/index.hbs' @ line 11 : column 0)
```