### PR TITLE
fix: Improve handling of hbs mangled by named-blocks-polyfill

### DIFF
--- a/lib/ast-transform.js
+++ b/lib/ast-transform.js
@@ -2,6 +2,51 @@
 'use strict';
 const stripIndent = require('strip-indent');
 
+function hasNamedBlocksPolyfillSyntax(node) {
+  return (
+    node.children.length === 1 &&
+    node.children[0].path.original === 'if' &&
+    node.children[0].params[0].path.original === '-is-named-block-invocation'
+  );
+}
+
+function extractFromNamedBlocksPolyfillSyntax(node) {
+  if (node.children[0].params[0].params[1].value === 'example') {
+    return node.children[0].program;
+  } else if (
+    node.children[0].inverse.body[0].params[0].params[1].value === 'example'
+  ) {
+    return node.children[0].inverse.body[0].program;
+  } else if (
+    node.children[0].inverse.body[0].inverse.body[0].params[0].params[1]
+      .value == 'example'
+  ) {
+    return node.children[0].inverse.body[0].inverse.body[0].program;
+  }
+}
+
+function cleanupNamedBlocksPolyfillSyntax(sourceString) {
+  sourceString = sourceString.trim();
+  sourceString = sourceString.replace(
+    /({{#if \(-is-named-block-invocation __arg0 "(.+?)"\)}})(\s*)(.*?)(\s*){{\/if}}/gs,
+    '\n  <:$2>$3$4$5</:$2>\n'
+  );
+  sourceString = sourceString.replace(
+    / @namedBlocksInfo={{hash .+?=0}} as \|__arg0\|/,
+    ''
+  );
+  sourceString = sourceString.replace(/(\s\s+)/g, '\n$1');
+  sourceString = sourceString.replace(/ @(\w+)=/g, '\n  @$1=');
+  sourceString =
+    sourceString +
+    `
+
+  <!-- Formatting lost due to named-blocks-polyfill. Fallback re-formatting applied.
+       Original source code formatting will be available once the polyfill is no longer needed. -->
+  `;
+  return sourceString;
+}
+
 class FreestyleSourceExtractionAstPlugin {
   constructor(env) {
     this.originalSource = env.contents;
@@ -33,10 +78,18 @@ class FreestyleSourceExtractionAstPlugin {
           // Due to a bug in ember, the current way to ensure this is to configure freestyle to run *after* named-blocks-polyfill
           // via the ember-addon section of freestyle's package.json. ¯\_(ツ)_/¯
           let exampleNode = node.children.find((n) => n.tag === ':example');
-          if (!exampleNode) {
+          let sourceString;
+          if (exampleNode) {
+            sourceString = plugin.extractSource(exampleNode.children);
+          } else if (hasNamedBlocksPolyfillSyntax(node)) {
+            // Unfortunately, we may still run after the named-blocks-polyfill when in an Ember Addon, so we do the best we can here.
+            exampleNode = extractFromNamedBlocksPolyfillSyntax(node);
+            sourceString = plugin.extractSource(exampleNode.body);
+            sourceString = cleanupNamedBlocksPolyfillSyntax(sourceString);
+          } else {
             exampleNode = node; // not using named blocks
+            sourceString = plugin.extractSource(exampleNode.children);
           }
-          const sourceString = plugin.extractSource(exampleNode.children);
           node.attributes.push(b.attr('@source', b.text(sourceString)));
         }
       },


### PR DESCRIPTION
- Ideally, freestyle's AST will run before the named-blocks-polyfill. If it doesn't, the syntax that it is looking for is very different. This commit addresses that. Note that formatting is lost by the named-blocks-polyfill. It would be better if the original authored formatting could be preserved.

Fixes #481