### PR TITLE
chore: update .npmignore file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,7 +6,9 @@
 /bower_components/
 
 # misc
+/.all-contributorsrc
 /.bowerrc
+/.dependabot
 /.editorconfig
 /.ember-cli
 /.env*
@@ -16,12 +18,22 @@
 /.git/
 /.github/
 /.gitignore
+/.node-version
+/.prettierignore
+/.prettierrc.js
+/.sass-lint.yml
 /.template-lintrc.js
 /.watchmanconfig
 /bower.json
+/Brewfile
+/config/deploy.js
 /config/ember-try.js
 /CONTRIBUTING.md
+/doc
 /ember-cli-build.js
+/FREESTYLE_USAGE_API.md
+/jsconfig.json
+/script
 /testem.js
 /tests/
 /yarn.lock


### PR DESCRIPTION
Should the following be added as well?

- `.all-contributorsrc` - Contributions can also be checked on GH
- `FREESTYLE_USAGE_API.md` - Seems like an API design file used for development