### PR TITLE
refactor: remove custom equal helpers

### DIFF
--- a/addon/components/freestyle-variant-list/index.hbs
+++ b/addon/components/freestyle-variant-list/index.hbs
@@ -1,7 +1,7 @@
 <ul class='FreestyleCollection-variantList'>
   {{#each @variants as |variantKey|}}
     <li
-      class='FreestyleCollection-variantListItem {{if (variant-eq @activeKey variantKey) 'FreestyleCollection-variantListItem--active'}}'
+      class='FreestyleCollection-variantListItem {{if (eq @activeKey variantKey) 'FreestyleCollection-variantListItem--active'}}'
       role="button"
       onclick={{fn this.onClickItem variantKey}}
     >

--- a/addon/helpers/equal.js
+++ b/addon/helpers/equal.js
@@ -1,3 +1,0 @@
-export function equalHelper(params) {
-  return params[0] === params[1];
-}

--- a/app/helpers/variant-eq.js
+++ b/app/helpers/variant-eq.js
@@ -1,4 +1,0 @@
-import { helper } from '@ember/component/helper';
-import { equalHelper } from 'ember-freestyle/helpers/equal';
-
-export default helper(equalHelper);


### PR DESCRIPTION
Since the project uses `ember-truth-helpers` again, seems like a good idea to use its `eq` helper instead of the custom `variant-eq` helper.