### PR TITLE
chore: clean up blueprint files

### DIFF
--- a/blueprints/ember-freestyle/files/__root__/app/controllers/freestyle.js
+++ b/blueprints/ember-freestyle/files/__root__/app/controllers/freestyle.js
@@ -1,60 +1,29 @@
-import Ember from 'ember';
 import BaseFreestyleController from 'ember-freestyle/controllers/freestyle';
 import { inject as service } from '@ember/service';
 
 export default class FreestyleController extends BaseFreestyleController {
   @service emberFreestyle;
 
-  /* BEGIN-FREESTYLE-USAGE fp--notes
-### A few notes regarding freestyle-palette
-
-- Accepts a colorPalette POJO like the one found in the freestyle.js blueprint controller
-- Looks very nice
-
-And another thing...
-
-###### Markdown note demonstrating prettified code
-
-```
-import Ember from 'ember';
-
-export default Ember.Component.extend({
-  // ...
-  colorPalette: {
-    'primary': {
-      'name': 'cyan',
-      'base': '#00bcd4'
-    },
-    'accent': {
-      'name': 'amber',
-      'base': '#ffc107'
-    }
-  }
-  // ...
-});
-```
-  END-FREESTYLE-USAGE */
-
   colorPalette = {
-    'primary': {
-      'name': 'cyan',
-      'base': '#00bcd4'
+    primary: {
+      name: 'cyan',
+      base: '#00bcd4',
     },
-    'accent': {
-      'name': 'amber',
-      'base': '#ffc107'
+    accent: {
+      name: 'amber',
+      base: '#ffc107',
     },
-    'secondary': {
-      'name': 'greyish',
-      'base': '#b6b6b6'
+    secondary: {
+      name: 'greyish',
+      base: '#b6b6b6',
     },
-    'foreground': {
-      'name': 'blackish',
-      'base': '#212121'
+    foreground: {
+      name: 'blackish',
+      base: '#212121',
     },
-    'background': {
-      'name': 'white',
-      'base': '#ffffff'
-    }
+    background: {
+      name: 'white',
+      base: '#ffffff',
+    },
   };
 }

--- a/blueprints/ember-freestyle/files/__root__/app/templates/freestyle.hbs
+++ b/blueprints/ember-freestyle/files/__root__/app/templates/freestyle.hbs
@@ -1,32 +1,26 @@
 <FreestyleGuide
-  @title='Ember Freestyle'
-  @subtitle='Living Style Guide'
+  @title="Ember Freestyle"
+  @subtitle="Living Style Guide"
 >
-  <FreestyleSection @name='Visual Style' as |Section|>
-    <Section.subsection @name='Typography'>
-
-      <FreestyleUsage @slug='typography-times' @title='Times New Roman'>
-        <FreestyleTypeface @fontFamily='Times New Roman' />
+  <FreestyleSection @name="Visual Style" as |Section|>
+    <Section.subsection @name="Typography">
+      <FreestyleUsage @slug="typography-times" @title="Times New Roman">
+        <FreestyleTypeface @fontFamily="Times New Roman" />
       </FreestyleUsage>
 
-      <FreestyleUsage @slug='typography-helvetica' @title='Helvetica'>
-        <FreestyleTypeface @fontFamily='Helvetica' />
+      <FreestyleUsage @slug="typography-helvetica" @title="Helvetica">
+        <FreestyleTypeface @fontFamily="Helvetica" />
       </FreestyleUsage>
-
     </Section.subsection>
 
-    <Section.subsection @name='Color'>
-
-      <FreestyleUsage @slug='fp' @title='Freestyle Palette' @usageTitle='Usage'>
-
+    <Section.subsection @name="Color">
+      <FreestyleUsage @slug="fp" @title="Freestyle Palette" @usageTitle="Usage">
         <FreestylePalette
           @colorPalette={{this.colorPalette}}
-          @title='Dummy App Color Palette'
-          @description='This component displays the color palette specified in freestyle/palette.json'
+          @title="Dummy App Color Palette"
+          @description="This component displays the color palette specified in app/controllers/freestyle.js"
         />
       </FreestyleUsage>
-
     </Section.subsection>
-
   </FreestyleSection>
 </FreestyleGuide>


### PR DESCRIPTION
- Makes sure the controller file does not fail prettier out of the box
- Removes the `BEGIN-FREESTYLE-USAGE` comment block as the current docs state that this functionality has been removed
- Updates the template file to use double quotes and changes `freestyle/palette.json` to `app/controllers/freestyle.js`
- I also removed some new lines in the template file to make it more consistent (let me know if this should be reverted)

Closes #525.