### PR TITLE
Resolve class-based plugin deprecation

### DIFF
--- a/lib/ast-transform.js
+++ b/lib/ast-transform.js
@@ -47,30 +47,29 @@ function cleanupNamedBlocksPolyfillSyntax(sourceString) {
   return sourceString;
 }
 
-class FreestyleSourceExtractionAstPlugin {
-  constructor(env) {
-    this.originalSource = env.contents;
-  }
+module.exports = function(env) {
+  const { builders: b } = env.syntax;
 
-  extractSource(nodes) {
+  const originalSource = env.contents;
+
+  const extractSource = (nodes) => {
     // nodes should be a contiguous collection of ast nodes
     let startNode = nodes[0];
     let endNode = nodes[nodes.length - 1];
     let start = startNode.loc.start;
     let end = endNode.loc.end;
-    let lines = this.originalSource.split('\n').slice(start.line - 1, end.line);
+    let lines = originalSource.split('\n').slice(start.line - 1, end.line);
     lines[0] = new Array(start.column).join(' ') + lines[0].slice(start.column);
     lines[lines.length - 1] = lines[lines.length - 1].slice(0, end.column);
     return stripIndent(lines.join('\n'));
-  }
+  };
 
-  transform(ast) {
-    const plugin = this;
-    const { builders: b } = this.syntax;
-    const visitor = {
+  return {
+    name: 'FreestyleSourceExtractionAstPlugin',
+    visitor: {
       ElementNode(node) {
         if (['FreestyleUsage', 'FreestyleDynamic'].includes(node.tag)) {
-          const sourceString = plugin.extractSource(node.children);
+          const sourceString = extractSource(node.children);
           node.attributes.push(b.attr('@source', b.text(sourceString)));
         }
         if (['Freestyle::Usage'].includes(node.tag)) {
@@ -80,15 +79,15 @@ class FreestyleSourceExtractionAstPlugin {
           let exampleNode = node.children.find((n) => n.tag === ':example');
           let sourceString;
           if (exampleNode) {
-            sourceString = plugin.extractSource(exampleNode.children);
+            sourceString = extractSource(exampleNode.children);
           } else if (hasNamedBlocksPolyfillSyntax(node)) {
             // Unfortunately, we may still run after the named-blocks-polyfill when in an Ember Addon, so we do the best we can here.
             exampleNode = extractFromNamedBlocksPolyfillSyntax(node);
-            sourceString = plugin.extractSource(exampleNode.body);
+            sourceString = extractSource(exampleNode.body);
             sourceString = cleanupNamedBlocksPolyfillSyntax(sourceString);
           } else {
             exampleNode = node; // not using named blocks
-            sourceString = plugin.extractSource(exampleNode.children);
+            sourceString = extractSource(exampleNode.children);
           }
           node.attributes.push(b.attr('@source', b.text(sourceString)));
         }
@@ -103,15 +102,10 @@ class FreestyleSourceExtractionAstPlugin {
               'templates/components/freestyle-dynamic.hbs'
             ))
         ) {
-          const sourceString = plugin.extractSource(node.program.body);
+          const sourceString = extractSource(node.program.body);
           node.hash.pairs.push(b.pair('source', b.string(sourceString)));
         }
       },
-    };
-
-    this.syntax.traverse(ast, visitor);
-    return ast;
-  }
-}
-
-module.exports = FreestyleSourceExtractionAstPlugin;
+    },
+  };
+};


### PR DESCRIPTION
ember-source 3.27+: Using class based template compilation plugins is deprecated, please update to the functional style