### PR TITLE
fix: Import htmlSafe from @ember/template

### DIFF
--- a/addon/components/freestyle-palette-item/index.js
+++ b/addon/components/freestyle-palette-item/index.js
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 import { computed } from '@ember/object';
 
 export default Component.extend({

--- a/addon/components/freestyle-typeface/index.js
+++ b/addon/components/freestyle-typeface/index.js
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 import { computed } from '@ember/object';
 
 export default Component.extend({

--- a/tests/dummy/app/components/x-bar/index.js
+++ b/tests/dummy/app/components/x-bar/index.js
@@ -1,6 +1,6 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 
 export default Component.extend({
   tagName: '',


### PR DESCRIPTION
The previous import [is deprecated](https://deprecations.emberjs.com/v3.x#toc_ember-string-htmlsafe-ishtmlsafe) starting with Ember 3.25.