### PR TITLE
Remove usage of `ember-native-dom-helpers`

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "ember-export-application-global": "^2.0.1",
     "ember-load-initializers": "^2.1.2",
     "ember-maybe-import-regenerator": "^0.1.6",
-    "ember-native-dom-helpers": "^0.7.0",
     "ember-page-title": "^6.0.3",
     "ember-qunit": "^5.1.2",
     "ember-resolver": "^8.0.2",

--- a/tests/integration/components/freestyle-palette-item/component-test.js
+++ b/tests/integration/components/freestyle-palette-item/component-test.js
@@ -2,7 +2,6 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { find } from 'ember-native-dom-helpers';
 
 module('Integration | Component | freestyle palette item', function (hooks) {
   setupRenderingTest(hooks);
@@ -10,15 +9,18 @@ module('Integration | Component | freestyle palette item', function (hooks) {
   test('it has a base background color', async function (assert) {
     assert.expect(1);
 
-    this.set('color', {
-      base: '#abcdef',
-    });
+    let color = '#abcdef';
 
-    await render(hbs`{{freestyle-palette-item color=color}}`);
+    this.color = {
+      base: color,
+    };
 
-    let backgroundColorStyle = 'style="background-color: #abcdef;"';
-    assert.ok(
-      find('.FreestylePaletteItem').innerHTML.indexOf(backgroundColorStyle) > -1
-    );
+    await render(hbs`
+      <FreestylePaletteItem @color={{this.color}} />
+    `);
+
+    assert
+      .dom('.FreestylePaletteItem-color')
+      .hasAttribute('style', `background-color: ${color};`);
   });
 });


### PR DESCRIPTION
Most helpers from `ember-native-dom-helpers` are part of `@ember/test-helpers` which is included in the default blueprint, but for the one test where we were using `ember-native-dom-helpers` we can simply use `qunit-dom` as well.