### PR TITLE
Move `@glimmer/component` to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "@ember/render-modifiers": "^1.0.2",
+    "@glimmer/component": "^1.0.3",
     "@glimmer/tracking": "^1.0.3",
     "ember-auto-import": "^1.10.1",
     "ember-cli-babel": "^7.23.0",
@@ -54,7 +55,6 @@
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.1.4",
-    "@glimmer/component": "^1.0.3",
     "all-contributors-cli": "^6.14.1",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",


### PR DESCRIPTION
As it's used within the `addon` folder.