### PR TITLE
Remove `glob` as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "ember-named-blocks-polyfill": "^0.2.4",
     "ember-runtime-enumerable-includes-polyfill": "^2.0.0",
     "ember-truth-helpers": "^3.0.0",
-    "glob": "^7.1.3",
     "macro-decorators": "^0.1.2",
     "sass": "^1.17.0",
     "strip-indent": "^3.0.0"


### PR DESCRIPTION
Doesn't seem to be used anymore.