### PR TITLE
Make AST plugin functional

### DIFF
--- a/lib/ast-transform.js
+++ b/lib/ast-transform.js
@@ -47,30 +47,28 @@ function cleanupNamedBlocksPolyfillSyntax(sourceString) {
   return sourceString;
 }
 
-class FreestyleSourceExtractionAstPlugin {
-  constructor(env) {
-    this.originalSource = env.contents;
-  }
+function extractSource(nodes, contents) {
+  // nodes should be a contiguous collection of ast nodes
+  let startNode = nodes[0];
+  let endNode = nodes[nodes.length - 1];
+  let start = startNode.loc.start;
+  let end = endNode.loc.end;
+  let lines = contents.split('\n').slice(start.line - 1, end.line);
+  lines[0] = new Array(start.column).join(' ') + lines[0].slice(start.column);
+  lines[lines.length - 1] = lines[lines.length - 1].slice(0, end.column);
+  return stripIndent(lines.join('\n'));
+}
 
-  extractSource(nodes) {
-    // nodes should be a contiguous collection of ast nodes
-    let startNode = nodes[0];
-    let endNode = nodes[nodes.length - 1];
-    let start = startNode.loc.start;
-    let end = endNode.loc.end;
-    let lines = this.originalSource.split('\n').slice(start.line - 1, end.line);
-    lines[0] = new Array(start.column).join(' ') + lines[0].slice(start.column);
-    lines[lines.length - 1] = lines[lines.length - 1].slice(0, end.column);
-    return stripIndent(lines.join('\n'));
-  }
+module.exports = function ({ contents, syntax }) {
+  const { builders: b } = syntax;
 
-  transform(ast) {
-    const plugin = this;
-    const { builders: b } = this.syntax;
-    const visitor = {
+  return {
+    name: 'component-freestyle-source-extracter',
+
+    visitor: {
       ElementNode(node) {
         if (['FreestyleUsage', 'FreestyleDynamic'].includes(node.tag)) {
-          const sourceString = plugin.extractSource(node.children);
+          const sourceString = extractSource(node.children, contents);
           node.attributes.push(b.attr('@source', b.text(sourceString)));
         }
         if (['Freestyle::Usage'].includes(node.tag)) {
@@ -80,15 +78,15 @@ class FreestyleSourceExtractionAstPlugin {
           let exampleNode = node.children.find((n) => n.tag === ':example');
           let sourceString;
           if (exampleNode) {
-            sourceString = plugin.extractSource(exampleNode.children);
+            sourceString = extractSource(exampleNode.children, contents);
           } else if (hasNamedBlocksPolyfillSyntax(node)) {
             // Unfortunately, we may still run after the named-blocks-polyfill when in an Ember Addon, so we do the best we can here.
             exampleNode = extractFromNamedBlocksPolyfillSyntax(node);
-            sourceString = plugin.extractSource(exampleNode.body);
+            sourceString = extractSource(exampleNode.body, contents);
             sourceString = cleanupNamedBlocksPolyfillSyntax(sourceString);
           } else {
             exampleNode = node; // not using named blocks
-            sourceString = plugin.extractSource(exampleNode.children);
+            sourceString = extractSource(exampleNode.children, contents);
           }
           node.attributes.push(b.attr('@source', b.text(sourceString)));
         }
@@ -103,15 +101,10 @@ class FreestyleSourceExtractionAstPlugin {
               'templates/components/freestyle-dynamic.hbs'
             ))
         ) {
-          const sourceString = plugin.extractSource(node.program.body);
+          const sourceString = extractSource(node.program.body, contents);
           node.hash.pairs.push(b.pair('source', b.string(sourceString)));
         }
       },
-    };
-
-    this.syntax.traverse(ast, visitor);
-    return ast;
-  }
-}
-
-module.exports = FreestyleSourceExtractionAstPlugin;
+    },
+  };
+};


### PR DESCRIPTION
Using a class was deprecated in [v3.27](https://github.com/emberjs/ember.js/blob/master/CHANGELOG.md#v3270-may-3-2021).
Related PR: https://github.com/emberjs/ember.js/pull/19429.