### PR TITLE
Deprecate `<FreestyleShowdownContent />` component

### DIFF
--- a/addon/components/freestyle-showdown-content/index.js
+++ b/addon/components/freestyle-showdown-content/index.js
@@ -1,5 +1,6 @@
 /* eslint-disable ember/no-component-lifecycle-hooks */
 /* eslint-disable ember/require-tagless-components */
+import { deprecate } from '@ember/debug';
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 
@@ -8,7 +9,20 @@ export default Component.extend({
 
   didInsertElement() {
     this._super(...arguments);
+
+    deprecate(
+      'The `<FreestyleShowdownContent />` component is deprecated. Please use `ember-cli-showdown` directly if you need Markdown support.',
+      false,
+      {
+        for: 'ember-freestyle',
+        id: 'freestyle-showdown-content-component',
+        since: '0.12.12',
+        until: '0.13.0',
+      }
+    );
+
     let pre = this.element.getElementsByTagName('pre');
+
     if (pre[0]) {
       this.emberFreestyle.highlight(pre[0]);
     }


### PR DESCRIPTION
The `since` and `until` values are still TBD.

Closes #608.