### PR TITLE
fix: pass down @hideControls argument

### DIFF
--- a/addon/components/freestyle/usage/array/index.hbs
+++ b/addon/components/freestyle/usage/array/index.hbs
@@ -5,6 +5,7 @@
   @description={{@description}}
   @required={{@required}}
   @defaultValue={{@defaultValue}}
+  @hideControls={{@hideControls}}
 >
   {{#each @items key=@identity as |item index|}}
     <div class="FreestyleUsageArray-item">

--- a/addon/components/freestyle/usage/bool/index.hbs
+++ b/addon/components/freestyle/usage/bool/index.hbs
@@ -4,6 +4,7 @@
   @description={{@description}}
   @required={{@required}}
   @defaultValue={{@defaultValue}}
+  @hideControls={{@hideControls}}
 >
   <Freestyle::Usage::Bool::Control
     @value={{@value}}

--- a/addon/components/freestyle/usage/number/index.hbs
+++ b/addon/components/freestyle/usage/number/index.hbs
@@ -4,6 +4,7 @@
   @description={{@description}}
   @required={{@required}}
   @defaultValue={{@defaultValue}}
+  @hideControls={{@hideControls}}
 >
   <Freestyle::Usage::Number::Control
     @value={{@value}}

--- a/addon/components/freestyle/usage/object/index.hbs
+++ b/addon/components/freestyle/usage/object/index.hbs
@@ -4,6 +4,7 @@
   @description={{@description}}
   @required={{@required}}
   @defaultValue={{@defaultValue}}
+  @hideControls={{@hideControls}}
 >
   <Freestyle::Usage::Object::Control
     @value={{@value}}

--- a/addon/components/freestyle/usage/string/index.hbs
+++ b/addon/components/freestyle/usage/string/index.hbs
@@ -5,6 +5,7 @@
   @required={{@required}}
   @array={{@array}}
   @defaultValue={{@defaultValue}}
+  @hideControls={{@hideControls}}
 >
   <Freestyle::Usage::String::Control
     @options={{@options}}

--- a/tests/integration/components/freestyle/usage/string-test.js
+++ b/tests/integration/components/freestyle/usage/string-test.js
@@ -48,4 +48,12 @@ module('Integration | Component | freestyle/usage/string', function (hooks) {
     assert.dom(SELECT_CONTROL).hasValue('Bob');
     await select(SELECT_CONTROL, 'Larry');
   });
+
+  test('Does not render the controls', async function (assert) {
+    await render(hbs`<Freestyle::Usage::String
+      @hideControls={{true}}
+    />`);
+
+    assert.dom(CONTROL).doesNotExist();
+  });
 });


### PR DESCRIPTION
Prevents controls from being rendered despite `@hideControls` being set to `true`.