### PR TITLE
Fix rendering too many submenus

### DIFF
--- a/addon/components/freestyle-menu/index.hbs
+++ b/addon/components/freestyle-menu/index.hbs
@@ -11,15 +11,17 @@
       <LinkTo @query={{hash f=null s=section.name ss=null}} class="FreestyleMenu-itemLink">
         {{section.name}}
       </LinkTo>
-      {{#each section.subsections as |subsection|}}
+      {{#if section.subsections.length}}
         <ul class="FreestyleMenu-submenu">
-          <li class="FreestyleMenu-submenuItem">
-            <LinkTo @query={{hash f=null s=section.name ss=subsection.name}} class="FreestyleMenu-submenuItemLink">
-              {{subsection.name}}
-            </LinkTo>
-          </li>
+          {{#each section.subsections as |subsection|}}
+            <li class="FreestyleMenu-submenuItem">
+              <LinkTo @query={{hash f=null s=section.name ss=subsection.name}} class="FreestyleMenu-submenuItemLink">
+                {{subsection.name}}
+              </LinkTo>
+            </li>
+          {{/each}}
         </ul>
-      {{/each}}
+      {{/if}}
     </li>
   {{/each}}
 </ul>


### PR DESCRIPTION
I noticed for submenus, we were rendering a `ul` tag _per_ submenu link:

<img width="351" alt="Screenshot 2022-08-18 at 14 51 13" src="https://user-images.githubusercontent.com/7403183/185399134-a6b1e8a0-3905-402a-b703-44217df13790.png">

If I'm not mistaken, there should be only one `ul` tag for a submenu, but including multiple `li` tags.

This PR should fix that.

NOTE: It's easier to review without whitespace changes.