### PR TITLE
Render headings instead of divs

### DIFF
--- a/addon/components/freestyle-guide/index.hbs
+++ b/addon/components/freestyle-guide/index.hbs
@@ -10,7 +10,7 @@
       <svg height="20px" class="FreestyleGuide-ctaIcon" style="enable-background:new 0 0 32 32;" version="1.1" viewBox="0 0 32 32" width="20px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><path d="M4,10h24c1.104,0,2-0.896,2-2s-0.896-2-2-2H4C2.896,6,2,6.896,2,8S2.896,10,4,10z M28,14H4c-1.104,0-2,0.896-2,2 s0.896,2,2,2h24c1.104,0,2-0.896,2-2S29.104,14,28,14z M28,22H4c-1.104,0-2,0.896-2,2s0.896,2,2,2h24c1.104,0,2-0.896,2-2 S29.104,22,28,22z"/></svg>
     </a>
     <div class="FreestyleGuide-titleContainer">
-      <div class="FreestyleGuide-title">{{@title}}</div>
+      <h1 class="FreestyleGuide-title">{{@title}}</h1>
       <div class="FreestyleGuide-subtitle">{{@subtitle}}</div>
     </div>
     <a

--- a/addon/components/freestyle-section/index.hbs
+++ b/addon/components/freestyle-section/index.hbs
@@ -5,9 +5,9 @@
 >
   {{#if this.show}}
     {{#if @name}}
-      <div class="FreestyleSection-name">
+      <h2 class="FreestyleSection-name">
         {{@name}}
-      </div>
+      </h2>
     {{/if}}
   {{/if}}
   {{yield

--- a/addon/components/freestyle-subsection/index.hbs
+++ b/addon/components/freestyle-subsection/index.hbs
@@ -4,9 +4,9 @@
 >
   {{#if this.show}}
     {{#if @name}}
-      <div class="FreestyleSubsection-name">
+      <h3 class="FreestyleSubsection-name">
         {{@name}}
-      </div>
+      </h3>
     {{/if}}
     {{yield}}
   {{/if}}


### PR DESCRIPTION
Currently the addon renders a bunch of divs instead of heading tags.
This is an accessibility issue.

Also I think it could be a good idea to render links with anchor inside each title. What do think? 