### PR TITLE
Make the navigation menu sticky

### DIFF
--- a/app/styles/components/freestyle-guide.scss
+++ b/app/styles/components/freestyle-guide.scss
@@ -92,8 +92,12 @@ $FreestyleGuide-boxShadow: 0 2px 5px 0 $FreestyleGuide-shadow1,
 
   &-nav {
     background-color: $FreestyleGuide-color--background;
+    height: 100vh;
     order: -1;
+    overflow: auto;
     padding: 1rem;
+    position: sticky;
+    top: 0;
 
     @include freestyle-breakpoint(large) {
       border-right: solid 1px $FreestyleGuide-color--secondary;

--- a/vendor/ember-freestyle.css
+++ b/vendor/ember-freestyle.css
@@ -69,8 +69,12 @@
 }
 .FreestyleGuide-nav {
   background-color: #fff;
+  height: 100vh;
   order: -1;
+  overflow: auto;
   padding: 1rem;
+  position: sticky;
+  top: 0;
 }
 @media (min-width: 600px) {
   .FreestyleGuide-nav {


### PR DESCRIPTION
Style-guide pages can get pretty long (specially in the `All` view). Making the navigation menu sticky avoids the user having to scroll back up when they want to navigate to a different section.

Related to #848.

Result:

https://user-images.githubusercontent.com/7403183/192954222-8e0ff202-1465-4769-be3c-84dc43c14dfb.mov