### PR TITLE
Fix compatibility with `ember-cli` v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16.x
           cache: yarn
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16.x
           cache: yarn
       - name: Install Dependencies
         run: yarn install --no-lockfile
@@ -72,7 +72,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16.x
           cache: yarn
       - name: Install Dependencies
         run: yarn install --frozen-lockfile

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ module.exports = {
   },
 
   setupPreprocessorRegistry(type, registry) {
-    if (type === 'self' && registry.app.name === 'ember-freestyle') {
+    if (type !== 'parent') {
       return;
     }
     let pluginObj = this._buildPlugin();

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
+    "@ember/string": "^3.1.1",
     "@ember/test-helpers": "^2.8.1",
     "@embroider/test-setup": "^1.8.3",
     "@glint/core": "^0.9.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1038,6 +1038,13 @@
     ember-cli-babel "^7.26.11"
     ember-modifier-manager-polyfill "^1.2.0"
 
+"@ember/string@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@ember/string/-/string-3.1.1.tgz#0a5ac0d1e4925259e41d5c8d55ef616117d47ff0"
+  integrity sha512-UbXJ+k3QOrYN4SRPHgXCqYIJ+yWWUg1+vr0H4DhdQPTy8LJfyqwZ2tc5uqpSSnEXE+/1KopHBE5J8GDagAg5cg==
+  dependencies:
+    ember-cli-babel "^7.26.6"
+
 "@ember/test-helpers@^2.8.1":
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/@ember/test-helpers/-/test-helpers-2.8.1.tgz#20f2e30d48172c2ff713e1db7fbec5352f918d4e"


### PR DESCRIPTION
Fix based on the code example shown [here](https://github.com/ember-cli/ember-cli-preprocess-registry#addon-usage).

Closes #927.