### PR TITLE
Add `@ember/string` as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,6 +135,9 @@
     "typescript": "^4.9.5",
     "webpack": "^5.76.0"
   },
+  "peerDependencies": {
+    "@ember/string": "^3.1.1"
+  },
   "engines": {
     "node": "14.* || >= 16"
   },


### PR DESCRIPTION
At the moment, we use `@ember/string` without declaring it as a peer dependency.
This breaks in Ember v5 as `@ember/string` has been removed from `ember-source`.
This signals to users that they need to install `@ember/string` themselves.
This is the same as how `ember-data` and other addons do it, making sure only one copy of `@ember/string` is installed (the one by the app).