### PR TITLE
fix: allow new major version of tracked-built-ins

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "json-formatter-js": "^2.3.4",
     "macro-decorators": "^0.1.2",
     "strip-indent": "^3.0.0",
-    "tracked-built-ins": "^3.1.0"
+    "tracked-built-ins": "^3.1.0 || ^4.0.0"
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,7 +48,7 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       tracked-built-ins:
-        specifier: ^3.1.0
+        specifier: ^3.1.0 || ^4.0.0
         version: 3.3.0
     devDependencies:
       '@ember/optional-features':


### PR DESCRIPTION
Now when including ember-freestyle as well as tracked-built-ins directly, the dependency version mismatch.

The major change in tracked-built-ins v4 is that the minimum typescript version is upgraded, but ember-freestyle satisfies this version requirement.