### PR TITLE
Remove deprecated use of inject

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       fail-fast: false
       matrix:
         try-scenario:
-          - ember-lts-4.4
+          - ember-lts-4.8
           - ember-lts-4.12
           - ember-lts-5.12
           - ember-6.12

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ To see Ember Freestyle in action, visit [https://chrislopresto.github.io/ember-f
 
 ## Compatibility
 
-* Ember.js v4.4 or above
-* Ember CLI v4.4 or above
+* Ember.js v4.8 or above
+* Ember CLI v4.8 or above
 * Node.js v20 or above
 * Ember Auto Import v2 or above
 

--- a/addon/components/freestyle-annotation/index.ts
+++ b/addon/components/freestyle-annotation/index.ts
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import EmberFreestyleService from '../../services/ember-freestyle';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 interface Signature {
   Element: HTMLDivElement;

--- a/addon/components/freestyle-collection/index.ts
+++ b/addon/components/freestyle-collection/index.ts
@@ -5,7 +5,7 @@ import { TrackedArray } from 'tracked-built-ins';
 import type { WithBoundArgs } from '@glint/template';
 import type FreestyleVariant from '../freestyle-variant';
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { and, not, reads } from 'macro-decorators';
 import { action } from '@ember/object';

--- a/addon/components/freestyle-guide/index.ts
+++ b/addon/components/freestyle-guide/index.ts
@@ -4,7 +4,7 @@ import Owner from '@ember/owner';
 import { isBlank } from '@ember/utils';
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { reads } from 'macro-decorators';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';

--- a/addon/components/freestyle-menu/index.ts
+++ b/addon/components/freestyle-menu/index.ts
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { reads } from 'macro-decorators';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/addon/components/freestyle-section/index.ts
+++ b/addon/components/freestyle-section/index.ts
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import type EmberFreestyleService from '../../services/ember-freestyle';
 import type { WithBoundArgs } from '@glint/template';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import FreestyleSubsection from '../freestyle-subsection';
 import Owner from '@ember/owner';
 

--- a/addon/components/freestyle-source/index.ts
+++ b/addon/components/freestyle-source/index.ts
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import EmberFreestyleService from '../../services/ember-freestyle';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { reads } from 'macro-decorators';
 import { get } from '@ember/object';
 import { modifier } from 'ember-modifier';

--- a/addon/components/freestyle-subsection/index.ts
+++ b/addon/components/freestyle-subsection/index.ts
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import EmberFreestyleService from '../../services/ember-freestyle';
 import Owner from '@ember/owner';
 

--- a/addon/components/freestyle-usage-controls/index.ts
+++ b/addon/components/freestyle-usage-controls/index.ts
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { schedule } from '@ember/runloop';
 import { capitalize } from '@ember/string';
 import type EmberFreestyleService from '../../services/ember-freestyle';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action, get, set } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { modifier } from 'ember-modifier';

--- a/addon/components/freestyle-usage/index.ts
+++ b/addon/components/freestyle-usage/index.ts
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import type EmberFreestyleService from 'ember-freestyle/services/ember-freestyle';
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { and, or, reads } from 'macro-decorators';
 /* eslint-enable @typescript-eslint/no-unused-vars */

--- a/addon/components/freestyle/usage/index.ts
+++ b/addon/components/freestyle/usage/index.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import Component from '@glimmer/component';
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 /* eslint-enable @typescript-eslint/no-unused-vars */
 import type EmberFreestyleService from '../../../services/ember-freestyle';

--- a/addon/controllers/freestyle.ts
+++ b/addon/controllers/freestyle.ts
@@ -2,7 +2,7 @@ import Controller from '@ember/controller';
 import type EmberFreestyleService from 'ember-freestyle/services/ember-freestyle';
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 // eslint-disable-next-line ember/no-computed-properties-in-native-classes
 import { alias } from '@ember/object/computed';
 /* eslint-enable @typescript-eslint/no-unused-vars */

--- a/addon/modifiers/ensure-freestyle-theme.ts
+++ b/addon/modifiers/ensure-freestyle-theme.ts
@@ -1,5 +1,5 @@
 import Modifier from 'ember-modifier';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import type EmberFreestyleService from '../services/ember-freestyle';
 
 interface Signature {

--- a/addon/modifiers/freestyle-highlight.ts
+++ b/addon/modifiers/freestyle-highlight.ts
@@ -1,6 +1,6 @@
 import Modifier from 'ember-modifier';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import type EmberFreestyleService from '../services/ember-freestyle';
 
 export default class FreestyleHighlight extends Modifier {

--- a/blueprints/ember-freestyle/files/__root__/app/controllers/freestyle.js
+++ b/blueprints/ember-freestyle/files/__root__/app/controllers/freestyle.js
@@ -1,5 +1,5 @@
 import BaseFreestyleController from 'ember-freestyle/controllers/freestyle';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class FreestyleController extends BaseFreestyleController {
   @service emberFreestyle;

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -8,10 +8,10 @@ module.exports = async function () {
     usePnpm: true,
     scenarios: [
       {
-        name: 'ember-lts-4.4',
+        name: 'ember-lts-4.8',
         npm: {
           devDependencies: {
-            'ember-source': '~4.4.0',
+            'ember-source': '~4.8.0',
           },
         },
       },
@@ -42,24 +42,16 @@ module.exports = async function () {
       {
         name: 'ember-release',
         npm: {
-          dependencies: {
-            'ember-auto-import': '^2.0.0',
-          },
           devDependencies: {
             'ember-source': await getChannelURL('release'),
-            webpack: '^5.0.0',
           },
         },
       },
       {
         name: 'ember-beta-failing',
         npm: {
-          dependencies: {
-            'ember-auto-import': '^2.0.0',
-          },
           devDependencies: {
             'ember-source': await getChannelURL('beta'),
-            webpack: '^5.0.0',
           },
         },
         allowedToFail: true,
@@ -67,12 +59,8 @@ module.exports = async function () {
       {
         name: 'ember-canary-failing',
         npm: {
-          dependencies: {
-            'ember-auto-import': '^2.0.0',
-          },
           devDependencies: {
             'ember-source': await getChannelURL('canary'),
-            webpack: '^5.0.0',
           },
         },
         allowedToFail: true,

--- a/package.json
+++ b/package.json
@@ -136,7 +136,8 @@
     "webpack": "^5.76.0"
   },
   "peerDependencies": {
-    "@ember/string": "^3.1.1 || ^4.0.0"
+    "@ember/string": "^3.1.1 || ^4.0.0",
+    "ember-source": ">= 4.8.0"
   },
   "pnpm": {
     "overrides": {

--- a/tests/dummy/app/routes/documentation.ts
+++ b/tests/dummy/app/routes/documentation.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 /* eslint-enable @typescript-eslint/no-unused-vars */
 

--- a/tests/dummy/app/templates/documentation.hbs
+++ b/tests/dummy/app/templates/documentation.hbs
@@ -249,7 +249,7 @@
 
     <pre><code class="javascript language-javascript">
   import Route from '@ember/routing/route';
-  import { inject as service } from '@ember/service';
+  import { service } from '@ember/service';
 
   export default class ApplicationRoute extends Route {
     @service emberFreestyle;


### PR DESCRIPTION
Closes #1021

Also updated the Ember try scenarios, and ember-source dependency to >4.8, which makes it a breaking change.