### PR TITLE
Widen @ember/string peer dep and add modern ember-try scenarios

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,9 @@ jobs:
           - ember-lts-3.24
           - ember-lts-3.28
           - ember-lts-4.4
+          - ember-lts-4.12
+          - ember-lts-5.12
+          - ember-6.12
           - ember-release
           - ember-beta
           - ember-canary

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -38,6 +38,30 @@ module.exports = async function () {
         },
       },
       {
+        name: 'ember-lts-4.12',
+        npm: {
+          devDependencies: {
+            'ember-source': '~4.12.0',
+          },
+        },
+      },
+      {
+        name: 'ember-lts-5.12',
+        npm: {
+          devDependencies: {
+            'ember-source': '~5.12.0',
+          },
+        },
+      },
+      {
+        name: 'ember-6.12',
+        npm: {
+          devDependencies: {
+            'ember-source': '~6.12.0',
+          },
+        },
+      },
+      {
         name: 'ember-release',
         npm: {
           dependencies: {

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "webpack": "^5.76.0"
   },
   "peerDependencies": {
-    "@ember/string": "^3.1.1"
+    "@ember/string": "^3.1.1 || ^4.0.0"
   },
   "engines": {
     "node": ">= 18"


### PR DESCRIPTION
## Summary

- Widen the `@ember/string` peer dependency from `^3.1.1` to `^3.1.1 || ^4.0.0` so consumers on Ember 5+ can adopt `@ember/string` 4.x without forcing a resolution override. `dasherize` and `capitalize` signatures are identical across 3.x and 4.x, so no runtime change is needed.
- Add `ember-lts-4.12`, `ember-lts-5.12`, and `ember-6.12` scenarios to `ember-try`. The previous highest LTS tested was 4.4.

## Test plan

- [x] `pnpm ember try:one ember-lts-4.12` — SUCCESS
- [x] `pnpm ember try:one ember-lts-5.12` — SUCCESS (52/52 tests)
- [x] `pnpm ember try:one ember-6.12` — SUCCESS
- [ ] CI runs the full `ember try:each` matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)