### PR TITLE
Raise floor to Ember 4.4 / Node 20 and drop stale polyfills

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,6 @@ jobs:
       fail-fast: false
       matrix:
         try-scenario:
-          - ember-lts-3.24
-          - ember-lts-3.28
           - ember-lts-4.4
           - ember-lts-4.12
           - ember-lts-5.12
@@ -64,7 +62,6 @@ jobs:
           - ember-release
           - ember-beta-failing
           - ember-canary-failing
-          - ember-classic
           - embroider-safe
           - embroider-optimized
 

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@
 /package.json.ember-try
 /package-lock.json.ember-try
 /yarn.lock.ember-try
+/pnpm-lock.ember-try.yaml
 
 # broccoli-debug
 /DEBUG/

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ To see Ember Freestyle in action, visit [https://chrislopresto.github.io/ember-f
 
 ## Compatibility
 
-* Ember.js v3.24 or above
-* Ember CLI v3.24 or above
-* Node.js v18 or above
+* Ember.js v4.4 or above
+* Ember CLI v4.4 or above
+* Node.js v20 or above
 * Ember Auto Import v2 or above
 
 ember-freestyle includes TypeScript types, and provides a template registry that can be imported from `ember-freestyle/template-registry` for Glint usage.

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -8,28 +8,6 @@ module.exports = async function () {
     usePnpm: true,
     scenarios: [
       {
-        name: 'ember-lts-3.24',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.24.3',
-            'ember-template-imports': null,
-          },
-        },
-        allowedToFail: true, // to fix this, we need some build-time logic to avoid trying to render gts component
-      },
-      {
-        name: 'ember-lts-3.28',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.28.0',
-            '@ember/test-helpers': '2.8.1',
-            'ember-qunit': '5.1.5',
-            '@types/ember__test-helpers': '^2.8.1',
-            '@types/ember-qunit': '^5.0.2',
-          },
-        },
-      },
-      {
         name: 'ember-lts-4.4',
         npm: {
           devDependencies: {
@@ -98,28 +76,6 @@ module.exports = async function () {
           },
         },
         allowedToFail: true,
-      },
-      {
-        name: 'ember-classic',
-        env: {
-          EMBER_OPTIONAL_FEATURES: JSON.stringify({
-            'application-template-wrapper': true,
-            'default-async-observers': false,
-            'template-only-glimmer-components': false,
-          }),
-        },
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.28.0',
-            '@ember/test-helpers': '2.8.1',
-            'ember-qunit': '5.1.5',
-            '@types/ember__test-helpers': '^2.8.1',
-            '@types/ember-qunit': '^5.0.2',
-          },
-          ember: {
-            edition: 'classic',
-          },
-        },
       },
       embroiderSafe(),
       embroiderOptimized(),

--- a/lib/ast-transform.js
+++ b/lib/ast-transform.js
@@ -2,52 +2,6 @@
 
 const stripIndent = require('strip-indent');
 
-function hasNamedBlocksPolyfillSyntax(node) {
-  return (
-    node.children.length === 1 &&
-    node.children[0].path &&
-    node.children[0].path.original === 'if' &&
-    node.children[0].params[0].path.original === '-is-named-block-invocation'
-  );
-}
-
-function extractFromNamedBlocksPolyfillSyntax(node) {
-  if (node.children[0].params[0].params[1].value === 'example') {
-    return node.children[0].program;
-  } else if (
-    node.children[0].inverse.body[0].params[0].params[1].value === 'example'
-  ) {
-    return node.children[0].inverse.body[0].program;
-  } else if (
-    node.children[0].inverse.body[0].inverse.body[0].params[0].params[1]
-      .value == 'example'
-  ) {
-    return node.children[0].inverse.body[0].inverse.body[0].program;
-  }
-}
-
-function cleanupNamedBlocksPolyfillSyntax(sourceString) {
-  sourceString = sourceString.trim();
-  sourceString = sourceString.replace(
-    /({{#if \(-is-named-block-invocation __arg0 "(.+?)"\)}})(\s*)(.*?)(\s*){{\/if}}/gs,
-    '\n  <:$2>$3$4$5</:$2>\n',
-  );
-  sourceString = sourceString.replace(
-    / @namedBlocksInfo={{hash .+?=0}} as \|__arg0\|/,
-    '',
-  );
-  sourceString = sourceString.replace(/(\s\s+)/g, '\n$1');
-  sourceString = sourceString.replace(/ @(\w+)=/g, '\n  @$1=');
-  sourceString =
-    sourceString +
-    `
-
-  <!-- Formatting lost due to named-blocks-polyfill. Fallback re-formatting applied.
-       Original source code formatting will be available once the polyfill is no longer needed. -->
-  `;
-  return sourceString;
-}
-
 function escapeCurlyBraces(s) {
   return s.replace(/\{/g, '&#123;').replace(/\}/g, '&#125;');
 }
@@ -77,18 +31,10 @@ module.exports = function ({ contents, syntax }) {
           node.attributes.push(b.attr('@source', b.text(sourceString)));
         }
         if (['Freestyle::Usage', 'FreestyleUsage'].includes(node.tag)) {
-          // Note: if the ember-named-blocks-polyfill polyfill AST transform executed before ours, our code will not work
-          // Due to a bug in ember, the current way to ensure this is to configure freestyle to run *after* named-blocks-polyfill
-          // via the ember-addon section of freestyle's package.json. ¯\_(ツ)_/¯
           let exampleNode = node.children.find((n) => n.tag === ':example');
           let sourceString;
           if (exampleNode) {
             sourceString = extractSource(exampleNode.children, contents);
-          } else if (hasNamedBlocksPolyfillSyntax(node)) {
-            // Unfortunately, we may still run after the named-blocks-polyfill when in an Ember Addon, so we do the best we can here.
-            exampleNode = extractFromNamedBlocksPolyfillSyntax(node);
-            sourceString = extractSource(exampleNode.body, contents);
-            sourceString = cleanupNamedBlocksPolyfillSyntax(sourceString);
           } else {
             exampleNode = node; // not using named blocks
             sourceString = extractSource(exampleNode.children, contents);

--- a/package.json
+++ b/package.json
@@ -39,13 +39,11 @@
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
     "ember-auto-import": "^2.4.3",
-    "ember-cached-decorator-polyfill": "^1.0.2",
     "ember-cli-babel": "^8.2.0",
     "ember-cli-htmlbars": "^6.3.0",
     "ember-cli-typescript": "^5.1.1",
     "ember-focus-trap": "^1.0.1",
     "ember-modifier": "^3.2.7 || ^4.0.0",
-    "ember-named-blocks-polyfill": "^0.2.5",
     "ember-truth-helpers": "^4.0.3",
     "json-formatter-js": "^2.3.4",
     "macro-decorators": "^0.1.2",
@@ -146,7 +144,7 @@
     }
   },
   "engines": {
-    "node": ">= 18"
+    "node": ">= 20"
   },
   "volta": {
     "node": "20.14.0",
@@ -162,11 +160,8 @@
     "configPath": "tests/dummy/config",
     "demoURL": "https://chrislopresto.github.io/ember-freestyle/",
     "versionCompatibility": {
-      "ember": ">= 2.4.0"
-    },
-    "after": [
-      "ember-named-blocks-polyfill"
-    ]
+      "ember": ">= 4.4.0"
+    }
   },
   "release-it": {
     "plugins": {
@@ -183,7 +178,7 @@
       "tokenRef": "GITHUB_AUTH"
     },
     "hooks": {
-      "after:release": "ember deploy production"
+      "after:release": "./node_modules/.bin/ember deploy production"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       ember-auto-import:
         specifier: ^2.4.3
         version: 2.8.1(@glint/template@1.4.0)(webpack@5.95.0)
-      ember-cached-decorator-polyfill:
-        specifier: ^1.0.2
-        version: 1.0.2(@babel/core@7.25.2)(@glint/template@1.4.0)(ember-source@4.12.4(@babel/core@7.25.2)(@glimmer/component@1.1.2(@babel/core@7.25.2))(@glint/template@1.4.0)(webpack@5.95.0))
       ember-cli-babel:
         specifier: ^8.2.0
         version: 8.2.0(@babel/core@7.25.2)
@@ -38,9 +35,6 @@ importers:
       ember-modifier:
         specifier: ^3.2.7 || ^4.0.0
         version: 4.2.0(@babel/core@7.25.2)(ember-source@4.12.4(@babel/core@7.25.2)(@glimmer/component@1.1.2(@babel/core@7.25.2))(@glint/template@1.4.0)(webpack@5.95.0))
-      ember-named-blocks-polyfill:
-        specifier: ^0.2.5
-        version: 0.2.5
       ember-truth-helpers:
         specifier: ^4.0.3
         version: 4.0.3(ember-source@4.12.4(@babel/core@7.25.2)(@glimmer/component@1.1.2(@babel/core@7.25.2))(@glint/template@1.4.0)(webpack@5.95.0))
@@ -1966,10 +1960,6 @@ packages:
     resolution: {integrity: sha512-CtWYYHU/MgK88rxMrLfkD356dApswtR/kWZ/c6JifG1m10e7tBBrs/366dFzWMAoqYmG5/JSh+94tUSpIwh+ag==}
     engines: {node: '>= 12.*'}
 
-  babel-import-util@1.4.1:
-    resolution: {integrity: sha512-TNdiTQdPhXlx02pzG//UyVPSKE7SNWjY0n4So/ZnjQpWwaM5LvWBLkWa1JKll5u06HNscHD91XZPuwrMg1kadQ==}
-    engines: {node: '>= 12.*'}
-
   babel-import-util@2.1.1:
     resolution: {integrity: sha512-3qBQWRjzP9NreSH/YrOEU1Lj5F60+pWSLP0kIdCWxjFHH7pX2YPHIxQ67el4gnMNfYoDxSDGcT0zpVlZ+gVtQA==}
     engines: {node: '>= 12.*'}
@@ -2489,8 +2479,8 @@ packages:
     resolution: {integrity: sha512-RbsNrFyhwkx+6psk/0fK/Q9orOUr9VMxohGd8vTa4djf4TGLfblBgUfqZChrZuW0Q+mz2eBPFLusw9Jfukzmhg==}
     hasBin: true
 
-  caniuse-lite@1.0.30001664:
-    resolution: {integrity: sha512-AmE7k4dXiNKQipgn7a2xg558IRqPN3jMQY/rOsbxDhrd0tyChwbITBfiwtnqz8bi2M5mIWbxAYBvk7W7QBUS2g==}
+  caniuse-lite@1.0.30001788:
+    resolution: {integrity: sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==}
 
   capture-exit@2.0.0:
     resolution: {integrity: sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==}
@@ -3206,16 +3196,6 @@ packages:
     resolution: {integrity: sha512-R5RpJmhycU6YKryzsIL/wP42r0e2PPfLRsFECoGvb1st2eEnU1Q7XyLVC1txd/XvURfu7x3Z7hKtZtYUxy61oQ==}
     engines: {node: 12.* || 14.* || >= 16}
 
-  ember-cache-primitive-polyfill@1.0.1:
-    resolution: {integrity: sha512-hSPcvIKarA8wad2/b6jDd/eU+OtKmi6uP+iYQbzi5TQpjsqV6b4QdRqrLk7ClSRRKBAtdTuutx+m+X+WlEd2lw==}
-    engines: {node: 10.* || >= 12}
-
-  ember-cached-decorator-polyfill@1.0.2:
-    resolution: {integrity: sha512-hUX6OYTKltAPAu8vsVZK02BfMTV0OUXrPqvRahYPhgS7D0I6joLjlskd7mhqJMcaXLywqceIy8/s+x8bxF8bpQ==}
-    engines: {node: 14.* || >= 16}
-    peerDependencies:
-      ember-source: ^3.13.0 || ^4.0.0 || >= 5.0.0
-
   ember-cli-autoprefixer@2.0.0:
     resolution: {integrity: sha512-WVwfcwRoSjoR7NMfzsS4yWmAhs7FF5BfWzvdcyhvKl4wNzv4QSx9rjVV4dVcnY7pnj19OlSgLaXZ5Rt/P6u6dw==}
     engines: {node: 12.* || 14.* || >= 16}
@@ -3403,10 +3383,6 @@ packages:
     peerDependenciesMeta:
       ember-source:
         optional: true
-
-  ember-named-blocks-polyfill@0.2.5:
-    resolution: {integrity: sha512-OVMxzkfqJrEvmiky7gFzmuTaImCGm7DOudHWTdMBPO7E+dQSunrcRsJMgO9ZZ56suqBIz/yXbEURrmGS+avHxA==}
-    engines: {node: 10.* || >= 12}
 
   ember-page-title@7.0.0:
     resolution: {integrity: sha512-oq6+HYbeVD/BnxIO5AkP4gWlsatdgW2HFO10F8+XQiJZrwa7cC7Wm54JNGqQkavkDQTgNSiy1Fe2NILJ14MmAg==}
@@ -9642,7 +9618,7 @@ snapshots:
   autoprefixer@10.4.20(postcss@8.4.47):
     dependencies:
       browserslist: 4.24.0
-      caniuse-lite: 1.0.30001664
+      caniuse-lite: 1.0.30001788
       fraction.js: 4.3.7
       normalize-range: 0.1.2
       picocolors: 1.1.0
@@ -9788,8 +9764,6 @@ snapshots:
       - supports-color
 
   babel-import-util@0.2.0: {}
-
-  babel-import-util@1.4.1: {}
 
   babel-import-util@2.1.1: {}
 
@@ -10751,12 +10725,12 @@ snapshots:
 
   browserslist@3.2.8:
     dependencies:
-      caniuse-lite: 1.0.30001664
+      caniuse-lite: 1.0.30001788
       electron-to-chromium: 1.5.29
 
   browserslist@4.24.0:
     dependencies:
-      caniuse-lite: 1.0.30001664
+      caniuse-lite: 1.0.30001788
       electron-to-chromium: 1.5.29
       node-releases: 2.0.18
       update-browserslist-db: 1.1.0(browserslist@4.24.0)
@@ -10852,7 +10826,7 @@ snapshots:
     dependencies:
       tmp: 0.0.28
 
-  caniuse-lite@1.0.30001664: {}
+  caniuse-lite@1.0.30001788: {}
 
   capture-exit@2.0.0:
     dependencies:
@@ -11415,30 +11389,6 @@ snapshots:
       - '@glint/template'
       - supports-color
       - webpack
-
-  ember-cache-primitive-polyfill@1.0.1(@babel/core@7.25.2):
-    dependencies:
-      ember-cli-babel: 7.26.11
-      ember-cli-version-checker: 5.1.2
-      ember-compatibility-helpers: 1.2.7(@babel/core@7.25.2)
-      silent-error: 1.1.1
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
-
-  ember-cached-decorator-polyfill@1.0.2(@babel/core@7.25.2)(@glint/template@1.4.0)(ember-source@4.12.4(@babel/core@7.25.2)(@glimmer/component@1.1.2(@babel/core@7.25.2))(@glint/template@1.4.0)(webpack@5.95.0)):
-    dependencies:
-      '@embroider/macros': 1.16.6(@glint/template@1.4.0)
-      '@glimmer/tracking': 1.1.2
-      babel-import-util: 1.4.1
-      ember-cache-primitive-polyfill: 1.0.1(@babel/core@7.25.2)
-      ember-cli-babel: 7.26.11
-      ember-cli-babel-plugin-helpers: 1.1.1
-      ember-source: 4.12.4(@babel/core@7.25.2)(@glimmer/component@1.1.2(@babel/core@7.25.2))(@glint/template@1.4.0)(webpack@5.95.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@glint/template'
-      - supports-color
 
   ember-cli-autoprefixer@2.0.0:
     dependencies:
@@ -12040,13 +11990,6 @@ snapshots:
       ember-source: 4.12.4(@babel/core@7.25.2)(@glimmer/component@1.1.2(@babel/core@7.25.2))(@glint/template@1.4.0)(webpack@5.95.0)
     transitivePeerDependencies:
       - '@babel/core'
-      - supports-color
-
-  ember-named-blocks-polyfill@0.2.5:
-    dependencies:
-      ember-cli-babel: 7.26.11
-      ember-cli-version-checker: 5.1.2
-    transitivePeerDependencies:
       - supports-color
 
   ember-page-title@7.0.0:

--- a/types/glimmer-tracking-cached.d.ts
+++ b/types/glimmer-tracking-cached.d.ts
@@ -1,4 +1,5 @@
-// Type augmentation for @cached (provided at runtime by ember-cached-decorator-polyfill)
+// Type augmentation for @cached. Runtime is provided natively by @glimmer/tracking
+// on Ember 4.4+, but the standalone @glimmer/tracking@1.1.2 types don't yet export it.
 import '@glimmer/tracking';
 
 declare module '@glimmer/tracking' {


### PR DESCRIPTION
## Summary

Breaking-release cleanup. Raises the supported floor and removes runtime polyfills whose features now ship natively.

### BREAKING CHANGES

- **Minimum Ember is now 4.4** (was 3.24). The \`ember-lts-3.24\`, \`ember-lts-3.28\`, and \`ember-classic\` scenarios are removed from \`config/ember-try.js\` and the CI matrix. \`ember-addon.versionCompatibility.ember\` bumped from \`>= 2.4.0\` to \`>= 4.4.0\`.
- **Minimum Node is now 20** (was 18). Node 18 reached EOL in April 2025; the Volta pin has been 20.x for a while.
- **\`ember-named-blocks-polyfill\`** removed (named blocks shipped in Ember 4.0). The AST-transform workarounds in \`lib/ast-transform.js\` (\`hasNamedBlocksPolyfillSyntax\`, \`extractFromNamedBlocksPolyfillSyntax\`, \`cleanupNamedBlocksPolyfillSyntax\`) and the \`after: [\"ember-named-blocks-polyfill\"]\` ember-addon entry go with it.
- **\`ember-cached-decorator-polyfill\`** removed (\`@cached\` is native in Ember 4.4+).

Consumers who need older Ember support should pin to \`0.23.x\`.

### Other cleanup

- **release hook fix**: \`after:release\` now runs \`./node_modules/.bin/ember deploy production\` directly so the deploy goes through Volta's Node shim (which honors the project pin) instead of whatever Node pnpm happens to spawn. The prior release hit \`util.isRegExp is not a function\` because pnpm used Node 24, where that API was removed, while the addon's old \`clean-css@3.x\` transitive still uses it.
- **caniuse-lite** bumped — silences the repeated \"caniuse-lite is outdated\" warnings during builds.
- **README** compatibility section updated.
- **\`types/glimmer-tracking-cached.d.ts\`** kept (runtime comes from Ember 4.4+, but \`@glimmer/tracking@1.1.2\` npm types still don't export \`cached\`) with an updated comment explaining why.
- **\`.gitignore\`**: add \`pnpm-lock.ember-try.yaml\`.

### Diff stat

8 files changed, 17 insertions(+), 178 deletions(-)

## Test plan

- [x] \`./node_modules/.bin/ember test\` passes (52/52)
- [x] \`pnpm lint\` passes (js, hbs, css, glint)
- [x] \`./node_modules/.bin/ember build --environment=production\` succeeds and no longer emits \"caniuse-lite is outdated\" warnings
- [ ] CI matrix: ember-lts-4.4, ember-lts-4.12, ember-lts-5.12, ember-6.12, ember-release, embroider-safe, embroider-optimized

🤖 Generated with [Claude Code](https://claude.com/claude-code)