### PR TITLE
Run release deploy under Volta-pinned Node

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
       "tokenRef": "GITHUB_AUTH"
     },
     "hooks": {
-      "after:release": "./node_modules/.bin/ember deploy production"
+      "after:release": "./script/deploy-production.sh"
     }
   }
 }

--- a/script/deploy-production.sh
+++ b/script/deploy-production.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Run `ember deploy production` under the Volta-pinned Node.
+#
+# `pnpm release` spawns this hook with _VOLTA_TOOL_RECURSION=1 set and
+# pnpm's own Node (the Volta default) ahead of Volta's shim directory in
+# PATH. Without the two overrides below, `./node_modules/.bin/ember`
+# shebangs into the wrong Node and breaks the old clean-css@3.x pulled
+# in transitively by ember-cli-preprocess-registry (util.isRegExp was
+# removed in Node 22).
+set -e
+unset _VOLTA_TOOL_RECURSION
+exec env PATH="$VOLTA_HOME/bin:$PATH" ./node_modules/.bin/ember deploy production


### PR DESCRIPTION
## Summary

0.24.0 released to npm successfully, but the `after:release` deploy hook failed. Investigation showed a pnpm + Volta interaction:

- `pnpm release` sets \`_VOLTA_TOOL_RECURSION=1\` in the env it passes to child processes. That env var tells Volta's shim to stop intercepting and just exec the current Node in PATH.
- pnpm also prepends its own Node — the Volta **default** (currently Node 24), not the project pin — to PATH ahead of Volta's shim directory.

Net effect: inside the hook, `./node_modules/.bin/ember` shebangs through `exec node`, which resolves to Node 24, not the pinned Node 20. The ancient \`clean-css@3.x\` pulled in transitively by \`ember-cli-preprocess-registry\` then throws \`util.isRegExp is not a function\` (removed in Node 22) and the deploy build aborts.

Fix: move the hook into a small shell script that unsets \`_VOLTA_TOOL_RECURSION\` and prepends \`\$VOLTA_HOME/bin\` to PATH before invoking ember-cli. With both overrides in place, \`node\` resolves to Volta's shim, which honors the project's Node 20 pin.

## Test plan

- [x] \`pnpm exec sh -c './script/deploy-production.sh'\` — succeeds under Node 20.14.0 (simulates the env pnpm hands to release-it hooks). Exit 0, gh-pages push included.
- [ ] Next \`pnpm release\` cuts cleanly without failing the deploy hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)